### PR TITLE
Add example for recognizing An and Sn on non deleted permutation modules

### DIFF
--- a/tst/slow/NonDeletedPermModuleRepOfSn.tst
+++ b/tst/slow/NonDeletedPermModuleRepOfSn.tst
@@ -1,0 +1,13 @@
+gap> SetInfoLevel(InfoRecog, 0);;
+gap> gens := GeneratorsOfGroup;;
+gap> l := gens(SymmetricGroup(10));;
+gap> ll := List(l,x->PermutationMat(x,10)) * Z(5)^0;;
+gap> m := GModuleByMats(ll,GF(5));;
+gap> s5 := List(ll,x->KroneckerProduct(x,x));;
+gap> m := GModuleByMats(s5,GF(5));;
+gap> c := MTX.CompositionFactors(m);;
+gap> i := Position(List(c,a->a.dimension), 28);;
+gap> g := Group(c[i].generators);;
+gap> ri := RecognizeGroup(g);;
+gap> Size(ri);
+3628800


### PR DESCRIPTION
Currently, if e.g. an Sn is given acting on a module that is not a
deleted permutation module, recognition is very inefficient.
An example is given in the file examples/NonDeletedPermModuleRepOfSn.g