### PR TITLE
Throw an error when making the documentation but pkg is already loaded

### DIFF
--- a/regen_doc.g
+++ b/regen_doc.g
@@ -1,6 +1,4 @@
 # Regenerate parts of the recog documentation from its source code
-
-SetPackagePath("recog", "./");
 LoadPackage("recog");
 
 GenerateMethodsXML := function(shortname, desc, db)


### PR DESCRIPTION
Now the `regen_doc.g` file tells the user to start GAP with the `-A`
command line argument.

Fixes #64.