### PR TITLE
Use non-ASCII characters directly in the bib

### DIFF
--- a/doc/recog.bib
+++ b/doc/recog.bib
@@ -1,5 +1,5 @@
 @incollection {IssacRecog,
-    AUTHOR = {Neunh{\"o}ffer, Max and Seress, {\'A}kos},
+    AUTHOR = {Neunhöffer, Max and Seress, Ákos},
      TITLE = {A data structure for a uniform approach to computations with
               finite groups},
  BOOKTITLE = {ISSAC 2006},


### PR DESCRIPTION
As you can see here <https://gap-packages.github.io/recog/doc/chapBib.html>, the non-ASCII characters are not displaying properly. I've just tried replacing them with the actual characters, and it seems to work fine.