### PR TITLE
FindHomDbPerm: Add link to genss package into description string of `StabilizerChain` method

### DIFF
--- a/gap/perm.gi
+++ b/gap/perm.gi
@@ -373,7 +373,12 @@ AddMethod(FindHomDbPerm, FindHomMethodsPerm.SnkSetswrSr,
           "tries to find jellyfish" );
 AddMethod(FindHomDbPerm, FindHomMethodsPerm.StabilizerChain,
           55, "StabilizerChain",
-          "for a permutation group using a stabilizer chain (genss)");
+          Concatenation(
+              "for a permutation group using a stabilizer chain via the ",
+              "<URL Text=\"genss package\">",
+              "https://gap-packages.github.io/genss/",
+              "</URL>"
+          ));
 AddMethod(FindHomDbPerm, FindHomMethodsPerm.StabChain,
           50, "StabChain",
           "for a permutation group using a stabilizer chain");


### PR DESCRIPTION
The method `StabilizerChain` in `FindHomDbPerm` uses the genss package.
This commits inserts a link to the genss package homepage into the
description string of the `StabilizerChain` method.