### PR TITLE
Add options and improve printing of tests

### DIFF
--- a/tst/quick/PermCycle.tst
+++ b/tst/quick/PermCycle.tst
@@ -1,0 +1,2 @@
+gap> g := CyclicGroup(IsPermGroup, 7);;
+gap> ri := RECOG.TestGroup(g,false,7, rec(tryNonGroupElements := true));;


### PR DESCRIPTION
This makes tests print even more information, and also adds some configurable options.

The main new feature, testing elements not in the group, is disabled by default as it fails for almost everything. A cycle perm test is added just to test this option works.