### PR TITLE
Add two entries to the bibliography

### DIFF
--- a/doc/intro.xml
+++ b/doc/intro.xml
@@ -23,7 +23,7 @@ framework to implement methods of group recognition, regardless of
 what computational representation is used. This means, that the code
 in this package is useful at least for permutation groups, matrix
 groups and projective groups.
-The setup is described in <Cite Key="IssacRecog"/>. <P/>
+The setup is described in <Cite Key="NS06"/>. <P/>
 
 The framework allows to build composition trees and handles the builtup
 and usage of these trees in a generic way. It also contains a

--- a/doc/intro.xml
+++ b/doc/intro.xml
@@ -49,7 +49,7 @@ Our own method selection is described in detail in Chapter <Ref
 Chap="methsel"/>, because it is interesting in its own right and might be
 useful in other circumstances.<P/>
 
-Chapter <Ref Chap="methods"/> describes the avalable <Q>FindHomomorphism</Q>
+Chapter <Ref Chap="methods"/> describes the available <Q>FindHomomorphism</Q>
 methods.<P/>
 
 Chapter <Ref Chap="afterrecog"/> explains what one can do with a

--- a/doc/methods.xml
+++ b/doc/methods.xml
@@ -460,6 +460,14 @@ a short list of the possible isomorphism types of <A>G</A>.
 
 </Subsection>
 
+<Subsection Label="LieTypeNonConstr">
+<Heading><C>LieTypeNonConstr</C></Heading>
+
+Recognise quasi-simple group of Lie type when characteristic is given.
+Based on <Cite Key="BKPS02"/> and <Cite Key="AB01"/>.
+
+</Subsection>
+
 <Subsection Label="StabilizerChain">
 <Heading><C>StabilizerChain</C></Heading>
 

--- a/doc/recog.bib
+++ b/doc/recog.bib
@@ -12,3 +12,33 @@
        DOI = {10.1145/1145768.1145811},
       NOTE = {https://doi.org/10.1145/1145768.1145811},
 }
+
+@article {BKPS02,
+  AUTHOR = {Babai, László and Kantor, William M. and Pálfy,
+            Péter P. and Seress, Ákos}
+   TITLE = {Black-box recognition of finite simple groups of Lie type by
+            statistics of element orders},
+ JOURNAL = {J. Group Theory},
+    YEAR = {2002},
+  VOLUME = {5},
+  NUMBER = {4},
+   PAGES = {383--401},
+ JOURNAL = {J. Group Theory},
+FJOURNAL = {Journal of Group Theory},
+    YEAR = {2002},
+    ISSN = {1433-5883},
+ MRCLASS = {20D06 (20P05)},
+MRNUMBER = {1931364},
+     DOI = {10.1515/jgth.2002.010},
+    NOTE = {https://doi.org/10.1515/jgth.2002.010},
+}
+
+@incollection {AB01,
+    AUTHOR = {Altseimer, Christine and Borovik, Alexandre V.},
+     TITLE = {Probabilistic recognition of orthogonal and symplectic groups},
+ BOOKTITLE = {Groups and computation, {III} ({C}olumbus, {OH}, 1999)},
+    VOLUME = {8},
+     PAGES = {1--20},
+ PUBLISHER = {de Gruyter, Berlin},
+      YEAR = {2001},
+}

--- a/doc/recog.bib
+++ b/doc/recog.bib
@@ -1,4 +1,4 @@
-@incollection {IssacRecog,
+@incollection {NS06,
     AUTHOR = {Neunhöffer, Max and Seress, Ákos},
      TITLE = {A data structure for a uniform approach to computations with
               finite groups},
@@ -9,4 +9,6 @@
       YEAR = {2006},
    MRCLASS = {68P05 (20D99 68W30)},
   MRNUMBER = {MR2289128},
+       DOI = {10.1145/1145768.1145811},
+      NOTE = {https://doi.org/10.1145/1145768.1145811},
 }

--- a/gap/almostsimple/lietype.gi
+++ b/gap/almostsimple/lietype.gi
@@ -2,12 +2,7 @@
 #/*   Recognise quasi-simple group of Lie type when             */
 #/*   characteristic is given                                   */
 #/*                                                             */
-#/*   Babai, Kantor, Palfy, Seress:
-#/*   "Black-box recognition of finite simple groups of Lie type
-#/*   by statistics of element orders", Journal of Group Theory
-#/*   5.4 (2002): 383-402.
-#/*   Altseimer & Borovik (2001)                                */
-#/*   provide theoretical basis for algorithms                  */
+#/* [BKPS02] & [AB01] provide theoretical basis for algorithms. */
 #/*                                                             */
 #/*   this version developed by Malle & O'Brien March 2001      */
 #/*                                                             */


### PR DESCRIPTION
These are the works cited at the top of `gap/almostsimple/lietype.gi`. I have replaced that text with the key for these works in the bibliography.

Since these new references are not actually cited yet in the documentation, they don't appear in the bibliography of the documentation when it is compiled. Is there a way of forcing all entries to appear in the bibliography, even though they're not cited (yet)? I'm not yet sure where the appropriate place would be in the manual to cite them yet.

_(This PR also fixes a tiny typo that I found, in a separate commit.)_