### PR TITLE
Add a missing comma to the bib file

### DIFF
--- a/doc/recog.bib
+++ b/doc/recog.bib
@@ -15,7 +15,7 @@
 
 @article {BKPS02,
   AUTHOR = {Babai, László and Kantor, William M. and Pálfy,
-            Péter P. and Seress, Ákos}
+            Péter P. and Seress, Ákos},
    TITLE = {Black-box recognition of finite simple groups of Lie type by
             statistics of element orders},
  JOURNAL = {J. Group Theory},
@@ -23,9 +23,7 @@
   VOLUME = {5},
   NUMBER = {4},
    PAGES = {383--401},
- JOURNAL = {J. Group Theory},
 FJOURNAL = {Journal of Group Theory},
-    YEAR = {2002},
     ISSN = {1433-5883},
  MRCLASS = {20D06 (20P05)},
 MRNUMBER = {1931364},


### PR DESCRIPTION
Sorry, my fault, that's a bit embarrassing. This was causing errors when compiled the documentation. I also removing some repeated lines.