### PR TITLE
Improve findgensNmeth

### DIFF
--- a/doc/recognition.xml
+++ b/doc/recognition.xml
@@ -687,8 +687,8 @@ about the kernel:
     to the list of arguments in <C>args</C>. That is, the following
     code is used to call the method:
 <Listing>
-    methgensN := findmethgensN(ri);
-    CallFuncList(methgensN(ri).method,Concatenation([ri],methgensN.args));
+    gensNmeth := findgensNmeth(ri);
+    CallFuncList(gensNmeth.method,Concatenation([ri],gensNmeth.args));
 </Listing>
 The record is initialised upon creation of the recognition info record
 to calling <Ref Func="FindKernelRandom"/> with one argument of 20 (FIXME: is 20 correct?) (in addition

--- a/gap/base/recognition.gi
+++ b/gap/base/recognition.gi
@@ -406,7 +406,7 @@ InstallGlobalFunction( PrintTreePos,
 InstallGlobalFunction( RecogniseGeneric,
   function(arg)
     # Assume all the generators have no memory!
-    local H,N,depth,done,i,knowledge,l,ll,methgensN,methoddb,allmethods,
+    local H,N,depth,done,i,knowledge,l,ll,gensNmeth,methoddb,allmethods,
           proj1,proj2,ri,rifac,riker,s,x,y,z,succ,counter;
 
     # Look after arguments:
@@ -548,9 +548,9 @@ InstallGlobalFunction( RecogniseGeneric,
         ForgetMemory(pregensfac(ri));   # TODO: get rid of ForgetMemory here!
 
         # Now create the kernel generators with the stored method:
-        methgensN := findgensNmeth(ri);
-        succ := CallFuncList(methgensN.method,
-                             Concatenation([ri],methgensN.args));
+        gensNmeth := findgensNmeth(ri);
+        succ := CallFuncList(gensNmeth.method,
+                             Concatenation([ri],gensNmeth.args));
     until succ;
 
     # If nobody has set how we produce preimages of the nicegens:


### PR DESCRIPTION
Improve documentation of findgensNmeth.
  - Fix an example
  - doc now states findgensNmeth has to have two components.

Rename local variable in RecogniseGeneric.