### PR TITLE
In FindHomMethodsPerm.PcgsForBlocks subgens can never be fail

### DIFF
--- a/gap/perm.gi
+++ b/gap/perm.gi
@@ -120,7 +120,7 @@ FindHomMethodsPerm.PcgsForBlocks := function(ri,G)
   blocks := ri!.blocks;   # we know them from above!
   subgens := List(GeneratorsOfGroup(G),g->RestrictedPerm(g,blocks[1]));
   pcgs := Pcgs(Group(subgens));
-  if subgens <> fail then
+  if pcgs <> fail then
       # We now know that the kernel is solvable, go directly to
       # the Pcgs method:
       return FindHomMethodsPerm.Pcgs(ri,G);


### PR DESCRIPTION
In `FindHomMethodsPerm.PcgsForBlocks` it is checked whether `subgens` is `fail`, but it is probably `pcgs` meant.
I think this didn't cause any problems as it is checked in `FindHomMethodsPerm.Pcgs` again. So this test is then maybe not necessary any longer. Also `pcgs` is currently computed twice, but maybe should be stored.

Done by @monschau, @munsee and me (the code part of the documentation group) on the SummerSchoolMGR.