### PR TITLE
Remove some documentation compilation warnings

### DIFF
--- a/doc/methods.xml
+++ b/doc/methods.xml
@@ -8,7 +8,7 @@ This is the chapter of the documentation describing the methods.
 <Heading>Methods for recognition</Heading>
 <Index><Package>recog</Package></Index>
 
-<Section Label="permmethods">
+<Section Label="genericmethods">
 <Heading>Methods for generic groups</Heading>
 
 The following methods can be equally applied to permutation, matrix and

--- a/doc/recog.bib
+++ b/doc/recog.bib
@@ -352,7 +352,7 @@ MRREVIEWER = {Alexander J. Hulpke},
    TITLE = {Constructive Recognition of Finite Groups},
     YEAR = {2009},
   SCHOOL = {RWTH Aachen},
-    NOTE = {https://github.com/neunhoef/habil/raw/master/habil_accepted.pdf},
+    NOTE = {https://github.com/neunhoef/habil},
 }
 
 @book {Ser03,


### PR DESCRIPTION
For some reason there were several annoying LaTeX errors when using the full URL to Max's habilitation thesis. So I've just shortened it to a link to the GitHub repo.

I also changed a duplicated label name in the documentation.