### PR TITLE
Improve documentation of functions in code and manual II

### DIFF
--- a/gap/matrix.gi
+++ b/gap/matrix.gi
@@ -626,6 +626,7 @@ end;
 #end;
 #
 RECOG.ExtractLowStuff := function(m,layer,blocks,lens,canbas)
+  #canbas ... canonical basis
   local block,i,j,k,l,pos,v,what,where;
   v := ZeroVector(lens[layer],m[1]);
   pos := 0;
@@ -642,6 +643,9 @@ RECOG.ExtractLowStuff := function(m,layer,blocks,lens,canbas)
       od;
   od;
   if canbas <> fail then
+      # needed because we assume for example in
+	  # SLPforElementFuncsMatrix.LowerLeftPGroup that we work
+	  # over a field of order p (not a p power)
       return BlownUpVector(canbas,v);
   else
       return v;
@@ -763,6 +767,11 @@ InstallGlobalFunction( FindKernelLowerLeftPGroup,
     return true;
   end );
 
+# computes a straight line program (SLP) of <g> for a p-group in <ri> (that
+# correspond to a lower left triangular matrix;
+# The SLP is constructed by using the elementar matrices to cancel out the
+# entries in <g>. The coefficents of the process create the SLP.
+# TODO Max H. wants to rewrite the code
 SLPforElementFuncsMatrix.LowerLeftPGroup := function(ri,g)
   # First project and calculate the vector:
   local done,h,i,l,layer,pow;
@@ -798,7 +807,7 @@ end;
 #! @BeginChunk LowerLeftPGroup
 #! This method is only called by a hint from <C>BlockLowerTriangular</C>
 #! as the kernel of the homomorphism mapping to the diagonal blocks.
-#! The method uses the fact the this kernel is a <M>p</M>-group where
+#! The method uses the fact that this kernel is a <M>p</M>-group where
 #! <M>p</M> is the characteristic of the underlying field. It exploits
 #! this fact and uses this special structure to find nice generators
 #! and a method to express group elements in terms of these.
@@ -846,7 +855,12 @@ FindHomMethodsMatrix.GoProjective := function(ri,G)
 end;
 
 #! @BeginChunk KnownStabilizerChain
-#! TODO. use an already known stabilizer chain for this group
+#! If a stabilizer chain is already known, then the kernel node is given
+#! knowledge about this known stabilizer chain, and the factor node is told to
+#! use homomorphism methods from the database for permutation groups.
+#! If a stabilizer chain of a parent node is already known this is used for
+#! the computation of a stabilizer chain of this node. This stabilizer chain
+#! is then used in the same way as above.
 #! @EndChunk
 FindHomMethodsMatrix.KnownStabilizerChain := function(ri,G)
   local S,hom;

--- a/gap/matrix.gi
+++ b/gap/matrix.gi
@@ -626,7 +626,6 @@ end;
 #end;
 #
 RECOG.ExtractLowStuff := function(m,layer,blocks,lens,canbas)
-  #canbas ... canonical basis
   local block,i,j,k,l,pos,v,what,where;
   v := ZeroVector(lens[layer],m[1]);
   pos := 0;
@@ -644,8 +643,8 @@ RECOG.ExtractLowStuff := function(m,layer,blocks,lens,canbas)
   od;
   if canbas <> fail then
       # needed because we assume for example in
-	  # SLPforElementFuncsMatrix.LowerLeftPGroup that we work
-	  # over a field of order p (not a p power)
+      # SLPforElementFuncsMatrix.LowerLeftPGroup that we work
+      # over a field of order p (not a p power)
       return BlownUpVector(canbas,v);
   else
       return v;
@@ -767,11 +766,14 @@ InstallGlobalFunction( FindKernelLowerLeftPGroup,
     return true;
   end );
 
-# computes a straight line program (SLP) of <g> for a p-group in <ri> (that
-# correspond to a lower left triangular matrix;
-# The SLP is constructed by using the elementar matrices to cancel out the
+# computes a straight line program (SLP) for an element <g> of a p-group
+# described by <ri> (that corresponds to a matrix group consisting of lower
+# triangular matrices).
+# The SLP is constructed by using matrices forming a pcgs (polycyclic
+# generating sequence) to cancel out the
 # entries in <g>. The coefficents of the process create the SLP.
-# TODO Max H. wants to rewrite the code
+# TODO Max H. wants to rewrite the code to work row-by-row
+# instead of blockwise; that should result in both simple and faster code.
 SLPforElementFuncsMatrix.LowerLeftPGroup := function(ri,g)
   # First project and calculate the vector:
   local done,h,i,l,layer,pow;

--- a/gap/perm.gi
+++ b/gap/perm.gi
@@ -113,7 +113,11 @@ FindHomMethodsPerm.Imprimitive :=
   end;
 
 #! @BeginChunk PcgsForBlocks
-#! TODO
+#! This method is called after a hint is set in
+#! <C>FindHomMethodsPerm.Imprimitive</C>. Therefore the group <A>G</A> preserves
+#! a non-trivial block system. The method checks whether or not the restriction
+#! of <A>G</A> on one block is solvable. If so <C>FindHomMethodsPerm.Pcgs</C> is
+#! called and otherwise <C>NeverApplicable</C> is returned.
 #! @EndChunk
 FindHomMethodsPerm.PcgsForBlocks := function(ri,G)
   local blocks,pcgs,subgens;
@@ -131,11 +135,11 @@ end;
 
 #! @BeginChunk BalTreeForBlocks
 #! This method creates a balanced composition tree for the kernel of an
-#! imprimitive group. This is guaranteed as
-#! <C>FindHomMethodsPerm.BalTreeForBlocks</C> is
-#! just called from <C>FindHomMethodsPerm.Imprimitive</C> and itself.
+#! imprimitive group. This is guaranteed as the method is just called
+#! from <C>FindHomMethodsPerm.Imprimitive</C>
+#! (see <Ref Subsect="Imprimitive"/>) and itself.
 #! The homomorphism for the split in the composition tree used is
-#! induced by the action of G on
+#! induced by the action of <A>G</A> on
 #! half of its blocks.
 #! @EndChunk
 FindHomMethodsPerm.BalTreeForBlocks := function(ri,G)
@@ -178,8 +182,10 @@ end;
 
 # Now to the small base groups using stabilizer chains:
 
-# Checks whether the Schreier tree labels coincide on all the levels of the
-# stabilizer chain <S>
+# The GAP manual suggests that the labels at each level of a stabiliser chain
+# are identical GAP objects, but it does not promise this.
+# This function tests whether the stabiliser chain has this property, and
+# gives an error if not.
 DoSafetyCheckStabChain := function(S)
   while IsBound(S.stabilizer) do
       if not(IsIdenticalObj(S.labels,S.stabilizer.labels)) then

--- a/gap/perm.gi
+++ b/gap/perm.gi
@@ -130,7 +130,8 @@ FindHomMethodsPerm.PcgsForBlocks := function(ri,G)
 end;
 
 #! @BeginChunk BalTreeForBlocks
-#! TODO
+#! This method creates a balanced tree with left (kernel) node acting on
+#! roughly half of the blocks.
 #! @EndChunk
 FindHomMethodsPerm.BalTreeForBlocks := function(ri,G)
   local blocks,cut,hom,lowerhalf,nrblocks,o,upperhalf,l,n;

--- a/gap/perm.gi
+++ b/gap/perm.gi
@@ -130,8 +130,13 @@ FindHomMethodsPerm.PcgsForBlocks := function(ri,G)
 end;
 
 #! @BeginChunk BalTreeForBlocks
-#! This method creates a balanced tree with left (kernel) node acting on
-#! roughly half of the blocks.
+#! This method creates a balanced composition tree for the kernel of an
+#! imprimitive group. This is guaranteed as
+#! <C>FindHomMethodsPerm.BalTreeForBlocks</C> is
+#! just called from <C>FindHomMethodsPerm.Imprimitive</C> and itself.
+#! The homomorphism for the split in the composition tree used is
+#! induced by the action of G on
+#! half of its blocks.
 #! @EndChunk
 FindHomMethodsPerm.BalTreeForBlocks := function(ri,G)
   local blocks,cut,hom,lowerhalf,nrblocks,o,upperhalf,l,n;
@@ -173,6 +178,8 @@ end;
 
 # Now to the small base groups using stabilizer chains:
 
+# Checks whether the Schreier tree labels coincide on all the levels of the
+# stabilizer chain <S>
 DoSafetyCheckStabChain := function(S)
   while IsBound(S.stabilizer) do
       if not(IsIdenticalObj(S.labels,S.stabilizer.labels)) then
@@ -243,6 +250,8 @@ FindHomMethodsPerm.StabilizerChainPerm := function(ri,G)
   return Success;
 end;
 
+# creates recursively a word for <g> using the Schreier tree labels
+# from the stabilizerchain <S>
 WordinLabels := function(word,S,g)
   local i,point,start;
   if not(IsBound(S.orbit) and IsBound(S.orbit[1])) then
@@ -269,6 +278,8 @@ WordinLabels := function(word,S,g)
   return word;
 end;
 
+# creates a straight line program for an element <g> using the
+# Schreier tree labels from the stabilizerchain <S>
 SLPinLabels := function(S,g)
   local i,j,l,line,word;
   word := WordinLabels([],S,g);

--- a/gap/perm.gi
+++ b/gap/perm.gi
@@ -251,7 +251,7 @@ FindHomMethodsPerm.StabilizerChainPerm := function(ri,G)
 end;
 
 # creates recursively a word for <g> using the Schreier tree labels
-# from the stabilizerchain <S>
+# from the stabilizer chain <S>
 WordinLabels := function(word,S,g)
   local i,point,start;
   if not(IsBound(S.orbit) and IsBound(S.orbit[1])) then
@@ -279,7 +279,7 @@ WordinLabels := function(word,S,g)
 end;
 
 # creates a straight line program for an element <g> using the
-# Schreier tree labels from the stabilizerchain <S>
+# Schreier tree labels from the stabilizer chain <S>
 SLPinLabels := function(S,g)
   local i,j,l,line,word;
   word := WordinLabels([],S,g);


### PR DESCRIPTION
Most functions in gap/perm.gi are commented in the code now. In case they appear in the documentation they also have now an AutoDoc entry.
Additionally some functions in gap/matrix.gi got a documenting comment.

Done by @monschau, @Munsee and me (the code part of the documentation group) on the SummerSchoolMGR.