### PR TITLE
Documentation: add more information about feedback options

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -226,11 +226,11 @@ PackageDoc := rec(
 Dependencies := rec(
   GAP := ">=4.9",
   NeededOtherPackages := [
+    ["AtlasRep", ">= 1.4.0"],
+    ["FactInt", ">= 1.5.2"],
     ["Forms", ">= 1.2"],
     ["genss", ">= 1.3"],
     ["Orb", ">= 3.4"],
-    ["FactInt", ">= 1.5.2"],
-    ["AtlasRep", ">= 1.4.0"],
   ],
   SuggestedOtherPackages := [],
   ExternalConditions := []

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ subdirectory called `recog`.
 This is all which is needed if you installed the package in the standard
 `pkg` subdirectory.
 
-Note that the recog package needs the `orb`, `genss`, `FactInt`,
-`AtlasRep` and `Forms` packages to work.
+Note that the recog package needs the `AtlasRep`, `FactInt`, `Forms`,
+`genss`, and `orb` packages to work.
 
 If you installed the package in another `pkg` directory than the standard
 `pkg` directory in your GAP 4 installation, then you have to add the path
@@ -34,9 +34,14 @@ startup script.
 Recompiling the documentation is possible by the command `gap makedoc.g`
 in the recog directory. But this should not be necessary.
 
-## Support
+## Feedback and support
 
-For bug reports, feature requests and suggestions, please refer to
-<https://github.com/gap-packages/recog/issues>.
+If you have any bug reports, feature requests, or suggestions, then please
+tell us via the
+[issue tracker on GitHub](https://github.com/gap-packages/recog/issues).
 
-
+In addition, the recog package has a mailing list, at
+<recog@gap-system.org>, which can be used for holding discussions,
+sharing information, and asking questions about the package.  You can find
+more information, and register to receive the mail sent to this list, at
+<https://mail.gap-system.org/mailman/listinfo/recog>.

--- a/doc/install.xml
+++ b/doc/install.xml
@@ -8,14 +8,24 @@ This is the chapter of the documentation describing the installation.
 <Heading>Installation of the <Package>recog</Package> package</Heading>
 <Index><Package>recog</Package></Index>
 
-To install this  package, just extract the package's  archive file to
-the  GAP  <F>pkg</F>  directory.<P/>
+To install this package, just extract the package's archive file to the &GAP;
+<F>pkg</F> directory.<P/>
 
-By default, the <Package>recog</Package> package is not automatically
-loaded by &GAP; when it is installed. You must load the package with
+If the <Package>recog</Package> package is not automatically loaded
+when &GAP; is started, then you must load the package with
 <C>LoadPackage("recog");</C> before its functions become available.<P/>
 
-<!-- TODO Write something concerning the required packages -->
+Note that the <Package>recog</Package> package needs the
+<Package>AtlasRep</Package>,
+<Package>FactInt</Package>,
+<Package>Forms</Package>,
+<Package>genss</Package>,
+and
+<Package>orb</Package>
+packages to work.
+
+Recompiling the documentation is possible by the command <C>gap makedoc.g</C>
+in the <F>recog</F> directory. But this should not be necessary.
 
 <!-- ############################################################ -->
 

--- a/doc/intro.xml
+++ b/doc/intro.xml
@@ -54,11 +54,18 @@ usage of this package.<P/>
 </Section>
 
 <Section Label="feedback">
-<Heading>Feedback</Heading>
+<Heading>Feedback and support</Heading>
 
-If you have any bug reports, feature requests, or suggestions about the
-package, please use our
-<URL Text="issue tracker">https://github.com/gap-packages/recog/issues</URL>.
+If you have any bug reports, feature requests, or suggestions, then please
+tell us via the <URL Text="issue tracker on
+GitHub">https://github.com/gap-packages/recog/issues</URL>. <P/>
+
+In addition, the <Package>recog</Package> package has a mailing list, at
+<URL Text="recog@gap-system.org">mailto:recog@gap-system.org</URL>,
+which can be used for holding discussions, sharing information, and asking
+questions about the package.  You can find more information, and register to
+receive the mail sent to this list, at
+<URL>https://mail.gap-system.org/mailman/listinfo/recog</URL>.
 
 </Section>
 


### PR DESCRIPTION
Mostly this is about advertising the mailing list.

I've also added something about the required packages to the installation page of the documentation, which was taken from the README. In doing so, I decided to have the required packages listed in a consistent (alphabetical) order.