### PR TITLE
PackageInfo.g: correct last release date

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -8,7 +8,7 @@ SetPackageInfo( rec(
 PackageName := "recog",
 Subtitle := "A collection of group recognition methods",
 Version := "1.3.2dev",
-Date := "15/04/2018", # dd/mm/yyyy format
+Date := "09/07/2019", # dd/mm/yyyy format
 License := "GPL-3.0-or-later",
 
 ##  Information about authors and maintainers.


### PR DESCRIPTION
Sure, a release date is kind of irrelevant for a development version. But I'd still feel happier with the date being the correct last release date rather than one with the wrong year.