### PR TITLE
More homomrangecheck

### DIFF
--- a/gap/base/recognition.gi
+++ b/gap/base/recognition.gi
@@ -528,7 +528,11 @@ InstallGlobalFunction( RecogniseGeneric,
               counter,").");
         fi;
         Add(depth,'F');
-        Assert(2, ForAll(GeneratorsOfGroup(H), x->ValidateHomomInput(ri, x)));
+        if ForAny(GeneratorsOfGroup(H), x->not ValidateHomomInput(ri, x)) then
+            # Our group fails to contain some of the generators of H!
+            return fail;
+        fi;
+
         rifac := RecogniseGeneric(
                   Group(List(GeneratorsOfGroup(H), x->ImageElm(Homom(ri),x))),
                   methodsforfactor(ri), depth, forfactor(ri) ); # TODO: change forfactor to hintsForFactor??)

--- a/gap/perm.gi
+++ b/gap/perm.gi
@@ -50,6 +50,7 @@ FindHomMethodsPerm.NonTransitive :=
     o := Orb(G,la,OnPoints);
     Enumerate(o);
     hom := OrbActionHomomorphism(G,o);
+    Setvalidatehomominput(ri, {ri,p} -> ForAll(o, x -> (x^p in o)));
     SetHomom(ri,hom);
     return Success;
   end;

--- a/gap/perm.gi
+++ b/gap/perm.gi
@@ -95,6 +95,7 @@ FindHomMethodsPerm.Imprimitive :=
 
     # Find the homomorphism:
     hom := ActionHomomorphism(G,blocks,OnSets);
+    Setvalidatehomominput(ri, {ri,p} -> OnSetsSets(blocks, p) = blocks);
     SetHomom(ri,hom);
 
     # Now we want to help recognising the kernel, we first check, whether

--- a/gap/perm.gi
+++ b/gap/perm.gi
@@ -146,7 +146,7 @@ end;
 #! half of its blocks.
 #! @EndChunk
 FindHomMethodsPerm.BalTreeForBlocks := function(ri,G)
-  local blocks,cut,hom,lowerhalf,nrblocks,o,upperhalf,l,n;
+  local blocks,cut,hom,lowerhalf,nrblocks,o,upperhalf,l,n,seto;
 
   blocks := ri!.blocks;
 
@@ -161,7 +161,12 @@ FindHomMethodsPerm.BalTreeForBlocks := function(ri,G)
   lowerhalf := blocks{[1..cut]};
   upperhalf := blocks{[cut+1..nrblocks]};
   o := Concatenation(upperhalf);
+  # The order of 'o' in the homom must align with forfactor(ri).blocks below
   hom := ActionHomomorphism(G,o);
+
+  # Make a set so checking validatehomominput is faster
+  seto := Immutable(Set(o));
+  Setvalidatehomominput(ri, {ri,p} -> ForAll(o, x -> x^p in seto));
   SetHomom(ri,hom);
   Setimmediateverification(ri,true);
   findgensNmeth(ri).args[1] := 3+cut;

--- a/gap/perm/giant.gi
+++ b/gap/perm/giant.gi
@@ -487,6 +487,9 @@ RECOG.SLPforSn :=  function( n, pi )
     if IsOne(pi) then
         return StraightLineProgramNC( [[1,0]], 2 );
     fi;
+    if LargestMovedPoint(pi) > n then
+        return fail;
+    fi;
 
     # we need the cycles of pi of length > 1 to be written such
     # that the minimum point is the initial point of the cycle
@@ -555,6 +558,9 @@ RECOG.SLPforAn :=  function( n, pi )
         return StraightLineProgramNC( [[1,0]], 2 );
     fi;
     if SignPerm( pi ) = -1 then
+        return fail;
+    fi;
+    if LargestMovedPoint(pi) > n then
         return fail;
     fi;
 

--- a/tst/broken/veryslow/PermSym8Subgroups.tst
+++ b/tst/broken/veryslow/PermSym8Subgroups.tst
@@ -1,1 +1,0 @@
-gap> RECOG.testAllSubgroups(SymmetricGroup(8), rec(tryNonGroupElements := true));;

--- a/tst/working/veryslow/PermSym10Subgroup.tst
+++ b/tst/working/veryslow/PermSym10Subgroup.tst
@@ -1,0 +1,1 @@
+gap> RECOG.testAllSubgroups(SymmetricGroup(10), rec(tryNonGroupElements := true));;

--- a/tst/working/veryslow/PermTrans16.tst
+++ b/tst/working/veryslow/PermTrans16.tst
@@ -1,0 +1,4 @@
+gap> for i in [1..NrTransitiveGroups(16)] do
+> grp := TransitiveGroup(16,i);;
+> RECOG.TestGroup(grp, false, Size(grp), rec(tryNonGroupElements := true));;
+> od;;


### PR DESCRIPTION
This is an extension of #98, which adds many more homomrangecheck calls, and also fixes an SLP bug in An and Sn.

WIth this (as the tests show), we can now hit all Subgroups of Sym(10), and all transitive groups of size 16. These numbers are chosen just to be large enough and run in "reasonable" time.

If we push much larger than this we start failing failures, but those are due to only recognising a subgroup instead of the whole group, not SLP/element problems.

This contains #98