### PR TITLE
Simplify and speed up IsPowerOfPrime

### DIFF
--- a/gap/classical.gi
+++ b/gap/classical.gi
@@ -34,23 +34,8 @@
 BindGlobal( "ClassicalMethDb", [] );
 #
 ###
-## Test whether n is a power of the prime p
-##
-IsPowerOfPrime := function( n, p )
-
-    local x;
-
-    if n <= 0 then return false; fi;
-
-    repeat
-        x := QuotientRemainder( n, p );
-        if x[2] <> 0 then return false; fi;
-        n := x[1];
-    until n = 1;
-
-    return true;
-
-end;
+# Test whether <n> (assumed integer) is a power of <p> (assumed positive prime)
+IsPowerOfPrime := {n, p} -> n > 1 and p ^ PVALUATION_INT(n, p) = n;
 
 
 # Check if m > 5 and the order of a basic lppd(d,q;e) element


### PR DESCRIPTION
There's nothing wrong with the old code for `IsPowerOfPrime`, but I expected that GAP would have a built-in function to do the same, and being GAP, it would probably be faster. That seemed to be near enough the case: there exists `IsPrimePowerInt`, which while much more complicated than this function, seems to perform well. Using it, I get the following speedup:
```
gap> Number([1 .. 10000000], n -> IsPowerOfPrimeOLD(n, 2)); time;
23
17340
gap> Number([1 .. 10000000], n -> IsPowerOfPrimeNEW(n, 2)); time;
23
2624
```
(Note that `IsPowerOfPrime` is only ever called for the prime `2` in recog. But the new one is faster for everything I tested.)

In the spirit of keeping `recog` simple, I propose that we merge this PR and reduce the amount of code in the package.