### PR TITLE
Replace many "Error"s with "ErrorNoReturn"

### DIFF
--- a/gap/AnSnOnFDPM.gi
+++ b/gap/AnSnOnFDPM.gi
@@ -1490,8 +1490,8 @@ RECOG.RecogniseFDPM := function(group, field, eps)
     # check fdpm.dim is largest for IsPreDoubleTransposition to
     # work
     if fdpm.dim < 6 then
-      Error( "This function only works for matrix groups of dimension",
-            " at least 6 over a field of this characteristic.");
+      ErrorNoReturn( "This function only works for matrix groups of dimension",
+                     " at least 6 over a field of this characteristic.");
       return fail;
     fi;
     # search for double transpositions
@@ -1503,8 +1503,8 @@ RECOG.RecogniseFDPM := function(group, field, eps)
   else
     # check fdpm.dim is largest for IsPre3Cycle to work
     if fdpm.dim < 4 then
-      Error( "This function only works for matrix groups of dimension",
-            " at least 4 over a field of this characteristic.");
+      ErrorNoReturn( "This function only works for matrix groups of dimension",
+                     " at least 4 over a field of this characteristic.");
       return fail;
     fi;
     # search for a 3-cycle

--- a/gap/almostsimple.gi
+++ b/gap/almostsimple.gi
@@ -217,7 +217,8 @@ InstallGlobalFunction( DoHintedLowIndex, function(ri,G,hint)
       repeat
           i := i + 1;
           if i > 10000 then
-              Error("possible infinite loop in DoHintedLowIndex, wrong hints?");
+              ErrorNoReturn("possible infinite loop in DoHintedLowIndex, ",
+                            "wrong hints?");
           fi;
           x := PseudoRandom(G);
       until Order(x) in hint.elordersstart;

--- a/gap/base/methsel.gi
+++ b/gap/base/methsel.gi
@@ -26,7 +26,7 @@ InstallGlobalFunction( "AddMethod", function(arg)
   # the comment.
   local comment,db,i,l,mr,p;
   if Length(arg) < 4 or Length(arg) > 5 then
-      Error("Usage: AddMethod(database,method,rank,stamp [,comment] );");
+      ErrorNoReturn("Usage: AddMethod(database,method,rank,stamp [,comment] );");
   fi;
   db := arg[1];
   mr := rec(method := arg[2],rank := arg[3],stamp := arg[4]);
@@ -74,7 +74,7 @@ InstallGlobalFunction( "CallMethods", function(arg)
     local i, methargs, ms, result, tolerance, tolerancelimit, db;
 
     if Length(arg) < 2 then
-        Error("CallMethods needs at least two arguments");
+        ErrorNoReturn("CallMethods needs at least two arguments");
     fi;
     db := arg[1];
     ms := rec(failedMethods := rec(), inapplicableMethods := rec());
@@ -146,7 +146,7 @@ InstallGlobalFunction( "CallMethods", function(arg)
                 return ms;
 
             else
-                Error("Recognition method return invalid result: ", result);
+                ErrorNoReturn("Recognition method return invalid result: ", result);
             fi;
         od;
         # Nothing worked, increase tolerance:

--- a/gap/base/recognition.gi
+++ b/gap/base/recognition.gi
@@ -121,7 +121,7 @@ InstallGlobalFunction( RecogniseGroup,
     elif IsMatrixGroup(G) then
         return RecogniseGeneric(G,FindHomDbMatrix,"");
     else
-        Error("Only matrix and permutation groups are supported");
+        ErrorNoReturn("Only matrix and permutation groups are supported");
     fi;
 
 # TODO: perhaps check if the result does not have IsReady set;
@@ -306,7 +306,7 @@ InstallMethod( GetElmOrd, "for a recognition info record and a record",
 #                 ri!.randr[pos] := Next(ri!.prodrep);
 #             fi;
 #             if not(IsMatrix(ri!.randr[pos])) then
-#                 Error("ppd elements only make sense for matrices");
+#                 ErrorNoReturn("ppd elements only make sense for matrices");
 #             fi;
 #             res := rec( el := ri!.randr[pos] );
 #             res.charpoly := CharacteristicPolynomial(ri!.field,ri!.field,
@@ -614,8 +614,8 @@ InstallGlobalFunction( RecogniseGeneric,
                 x := RandomElm(ri,"KERNELANDVERIFY",true).el;
                 s := SLPforElement(rifac,ImageElm( Homom(ri), x!.el ));
                 if s = fail then
-                    Error("Very bad: factor was wrongly recognised and we ",
-                          "found out too late");
+                    ErrorNoReturn("Very bad: factor was wrongly recognised and we ",
+                                  "found out too late");
                 fi;
                 y := ResultOfStraightLineProgram(s,
                    ri!.genswithmem{[ri!.nrgensH+1..Length(ri!.genswithmem)]});
@@ -637,8 +637,8 @@ InstallGlobalFunction( RecogniseGeneric,
                 Info(InfoRecog,2,"Have now ",Length(gensN(ri)),
                      " generators for kernel, recognising...");
                 if succ = false then
-                    Error("Very bad: factor was wrongly recognised and we ",
-                          "found out too late");
+                    ErrorNoReturn("Very bad: factor was wrongly recognised and we ",
+                                  "found out too late");
                 fi;
             fi;
         fi;
@@ -782,12 +782,12 @@ InstallGlobalFunction( RandomSubproduct, function(a)
     elif IsList(a) then
         if Length(a) = 0 or
             not IsMultiplicativeElementWithInverse(a[1]) then
-            Error("<a> must be a nonempty list of group elements");
+            ErrorNoReturn("<a> must be a nonempty list of group elements");
         fi;
         prod := One(a[1]);
         list := a;
     else
-        Error("<a> must be a group or a nonempty list of group elements");
+        ErrorNoReturn("<a> must be a group or a nonempty list of group elements");
     fi;
 
     for g in list do
@@ -871,7 +871,7 @@ InstallOtherMethod( Size, "for a recognition info record",
 InstallOtherMethod( Size, "for a failed recognition info record",
   [IsRecognitionInfo],
   function(ri)
-    Error("the recognition described by this info record has failed!");
+    ErrorNoReturn("the recognition described by this info record has failed!");
   end);
 
 InstallOtherMethod( \in, "for a group element and a recognition info record",
@@ -893,7 +893,7 @@ InstallOtherMethod( \in, "for a group element and a recognition info record",
 InstallOtherMethod( \in, "for a group element and a recognition info record",
   [IsObject, IsRecognitionInfo],
   function( el, ri )
-    Error("the recognition described by this info record has failed!");
+    ErrorNoReturn("the recognition described by this info record has failed!");
   end);
 
 InstallGlobalFunction( "DisplayCompositionFactors", function(arg)
@@ -1156,7 +1156,7 @@ RECOG.TestRecognitionNode := function(ri,stop,recurse)
           y := ResultOfStraightLineProgram(slp,NiceGens(ri));
       fi;
       if slp = fail or not(ri!.isone(x/y)) then
-          if stop then Error("Error found, look at x, slp and y"); fi;
+          if stop then ErrorNoReturn("ErrorNoReturn found, look at x, slp and y"); fi;
           err := err + 1;
           Print("X\c");
       else

--- a/gap/c3c5.gi
+++ b/gap/c3c5.gi
@@ -52,10 +52,10 @@ RECOG.WriteOverBiggerFieldWithSmallerDegreeFinder := function(m)
   local F,bas,d,dim,e,fac,facs,gens,i,inforec,j,k,mp,mu,new,newgens,pr,q,v;
 
   if not(MTX.IsIrreducible(m)) then
-      Error("cannot work for reducible modules");
+      ErrorNoReturn("cannot work for reducible modules");
   fi;
   if MTX.IsAbsolutelyIrreducible(m) = true then
-      Error("cannot work for absolutely irreducible modules");
+      ErrorNoReturn("cannot work for absolutely irreducible modules");
   fi;
 
   F := MTX.Field(m);
@@ -351,7 +351,7 @@ RECOG.ForceToOtherField := function(m,fieldsize)
       w := List(v,x->x);  # this unpacks
       # Note: we used to call ConvertToVectorRep(w,fieldsize), which
       # also would save us work down the line; however, unfortunately
-      # this may run into an Error instead of returning fail, so we have
+      # this may run into an error instead of returning fail, so we have
       # to resort to the following, which is somewhat less efficient if
       # some rows are already defined over subfields.
       q := ConvertToVectorRep(w);
@@ -627,12 +627,12 @@ FindHomMethodsProjective.C3C5 := function(ri,G)
       collf := MTX.CollectedFactors(m);
       if Length(collf) = 1 then    # only one homogeneous component!
           if MTX.Dimension(collf[1][1]) = 1 then
-              Error("This should never have happened (2), tell Max.");
+              ErrorNoReturn("This should never have happened (2), tell Max.");
               # This should have been caught by the scalar test above.
           fi;
           Info(InfoRecog,2,"Restriction to H is homogeneous.");
           if not(MTX.IsAbsolutelyIrreducible(collf[1][1])) then
-              Error("Is this really possible??? G acts absolutely irred!");
+              ErrorNoReturn("Is this really possible??? G acts absolutely irred!");
           fi;
           homs := MTX.Homomorphisms(collf[1][1],m);
           basis := Concatenation(homs);
@@ -648,7 +648,7 @@ FindHomMethodsProjective.C3C5 := function(ri,G)
           if not(ForAll(kro,k->k[1] = true)) then
               Info(InfoRecog,1,"VERY, VERY, STRANGE!");
               Info(InfoRecog,1,"False alarm, was not a tensor decomposition.");
-              Error("This should never have happened (3), tell Max.");
+              ErrorNoReturn("This should never have happened (3), tell Max.");
           fi;
 
           H := GroupWithGenerators(conjgensG);

--- a/gap/c6.gi
+++ b/gap/c6.gi
@@ -172,7 +172,7 @@ RECOG.RadBasis:=function(r,n,q,rad)
         action := TransposedMatMutable(action);
 
 if Length(action) <> Length(nicebasis) then
-    Error("what's wrong?");
+    ErrorNoReturn("what's wrong?");
 fi;
 
     # The identical rows of action correspond to vectors in
@@ -180,7 +180,7 @@ fi;
     s := Set( action );
 
 if Length(nicebasis) mod Length(s)  <> 0 then
-    Error("what's wrong2?");
+    ErrorNoReturn("what's wrong2?");
 fi;
     # all vectors in nicebasis whose rows in action are
     # identical form a block
@@ -779,8 +779,8 @@ SMTX_InvariantBilinearForm := function ( module )
 
    if not SMTX.IsMTXModule(module) or
                             not SMTX.IsAbsolutelyIrreducible(module) then
-      Error(
- "Argument of InvariantBilinearForm is not an absolutely irreducible module");
+      ErrorNoReturn("Argument of InvariantBilinearForm is not an absolutely",
+                    " irreducible module");
    fi;
    if IsBound(module.InvariantBilinearForm) then
      return module.InvariantBilinearForm;
@@ -829,20 +829,20 @@ RECOG.MakeC6Group := function(g,over,p)
     f := DefaultFieldOfMatrixGroup(g);
     r := Characteristic(f);
     if Size(f) <> r then
-        Error("Must be over prime field");
+        ErrorNoReturn("Must be over prime field");
     fi;
     if p = r then
-        Error("Must be another characteristic");
+        ErrorNoReturn("Must be another characteristic");
     fi;
     if p =2 or r =2 then
-        Error("Odd characteristics only please");
+        ErrorNoReturn("Odd characteristics only please");
     fi;
     q := p;
     while (q-1) mod r <> 0 do
         q := q*p;
     od;
     if q > 65536 then
-        Error("field too big");
+        ErrorNoReturn("field too big");
     fi;
     zeta := Z(q)^((q-1)/r);
     #
@@ -851,7 +851,7 @@ RECOG.MakeC6Group := function(g,over,p)
     gm := GModuleByMats(GeneratorsOfGroup(over),f);
     M := MTX.InvariantBilinearForm(gm);
     if TransposedMat(M) <> -M then
-        Error("form not symplectic");
+        ErrorNoReturn("form not symplectic");
     fi;
     #
     # Now convert that into the "standard" symplectic form

--- a/gap/classicalnatural.gi
+++ b/gap/classicalnatural.gi
@@ -969,7 +969,7 @@ end;
 #           zf := yf;
 #           if not(IsZero(z[n,n])) or not(IsOne(z[n,n+1])) or
 #              not(IsZero(z[n+1,n+1])) or not(IsOne(z[n+1,n])) then
-#               Error("How on earth could this happen???");
+#               ErrorNoReturn("How on earth could this happen???");
 #           fi;
 #       else  # q > 2
 #           while true do   # will be left by break when we had success!
@@ -1253,7 +1253,7 @@ RECOG.RecogniseSL2NaturalEvenChar := function(g,f,torig)
 
   ch := Factors(CharacteristicPolynomial(f,f,t,1));
   if Length(ch) <> 2 or ch[1] <> ch[2] then
-      Error("matrix is not triagonalizable - this should never happen!");
+      ErrorNoReturn("matrix is not triagonalizable - this should never happen!");
   fi;
 
   one := OneMutable(t);
@@ -1342,7 +1342,7 @@ RECOG.RecogniseSL2NaturalEvenChar := function(g,f,torig)
               x[2] := x[2] + x[1] * el;
               if x <> bas*StripMemory(xm)*bas^-1 then
                 # FIXME: sometimes triggered by RecognizeGroup(GL(2,16));
-                Error("!!!");
+                ErrorNoReturn("!!!");
               fi;
           fi;
           # now x[2,2] is equal to One(f)
@@ -1961,7 +1961,7 @@ RECOG.SLn_UpStep := function(w)
             fi;
         od;
     else
-        Error("either i or j must be equal to n");
+        ErrorNoReturn("either i or j must be equal to n");
     fi;
     return el;
   end;
@@ -1991,7 +1991,7 @@ RECOG.SLn_UpStep := function(w)
             fi;
         od;
     else
-        Error("either i or j must be equal to n");
+        ErrorNoReturn("either i or j must be equal to n");
     fi;
     return el;
   end;
@@ -2020,7 +2020,7 @@ RECOG.SLn_UpStep := function(w)
             sf := w.slnstdf[2*w.ext+1];
           fi;
       else
-          Error("this program only works for odd n or n=2");
+          ErrorNoReturn("this program only works for odd n or n=2");
       fi;
   else
       # In this case the n-1-cycle is the identity, so we take a transvection:
@@ -2417,7 +2417,7 @@ end;
 #   one := One(f);
 #   gram := ZeroMatrix(l,l,vecs);
 #   n := RowLength(vecs)/2;
-#   Assert(1,IsInt(n),Error("RowLength must be even"));
+#   Assert(1,IsInt(n),ErrorNoReturn("RowLength must be even"));
 #   for i in [1..l] do
 #     for j in [i+1..l] do
 #       v := zero;
@@ -2700,7 +2700,7 @@ end;
 #           fi;
 #         else
 #           if Size(s.f) = 2 then
-#             Error("This does not work for GF(2).");
+#             ErrorNoReturn("This does not work for GF(2).");
 #           fi;
 #           t := t * s.delta;
 #           v[2*n-1] := v[2*n-1] * zeta;
@@ -2713,7 +2713,7 @@ end;
 #           fi;
 #           coeff := zeta;
 #         fi;
-#         Assert(1,v=vorig*t and (M = fail or Morig*t=M),Error("Hallo 0"));
+#         Assert(1,v=vorig*t and (M = fail or Morig*t=M),ErrorNoReturn("Hallo 0"));
 #       fi;
 #       if IsZero(v[ei]) or not(IsZero(coeff-v[fI])) then
 #         # The first easy case:
@@ -2733,7 +2733,7 @@ end;
 #               M[l,2*n] := M[l,2*n] + sc2;
 #             od;
 #           fi;
-#           Assert(1,v=vorig*t and (M = fail or Morig*t=M),Error("Hallo 1"));
+#           Assert(1,v=vorig*t and (M = fail or Morig*t=M),ErrorNoReturn("Hallo 1"));
 #         fi;
 #         # Now kill v[fI] if need be:
 #         if not(IsZero(v[fI])) then
@@ -2751,7 +2751,7 @@ end;
 #               M[l,2*n] := M[l,2*n] + sc2;
 #             od;
 #           fi;
-#           Assert(1,v=vorig*t and (M = fail or Morig*t=M),Error("Hallo 2"));
+#           Assert(1,v=vorig*t and (M = fail or Morig*t=M),ErrorNoReturn("Hallo 2"));
 #         fi;
 #       elif not(IsZero(one+v[ei])) then
 #         # The second easy case:
@@ -2771,7 +2771,7 @@ end;
 #             M[l,2*n] := M[l,2*n] + sc2;
 #           od;
 #         fi;
-#         Assert(1,v=vorig*t and (M = fail or Morig*t=M),Error("Hallo 3"));
+#         Assert(1,v=vorig*t and (M = fail or Morig*t=M),ErrorNoReturn("Hallo 3"));
 #         # Now kill v[ei] if need be:
 #         sc := -v[ei]/coeff;
 #         si := IntVecFFE(Coefficients(s.can,sc));
@@ -2787,7 +2787,7 @@ end;
 #             M[l,2*n] := M[l,2*n] + sc2;
 #           od;
 #         fi;
-#         Assert(1,v=vorig*t and (M = fail or Morig*t=M),Error("Hallo 4"));
+#         Assert(1,v=vorig*t and (M = fail or Morig*t=M),ErrorNoReturn("Hallo 4"));
 #       fi;
 #       if coeff = zeta then
 #         # Fix the e_n coefficient again:
@@ -2800,7 +2800,7 @@ end;
 #             M[l,2*n] := M[l,2*n] * zeta;
 #           od;
 #         fi;
-#         Assert(1,v=vorig*t and (M = fail or Morig*t=M),Error("Hallo 5"));
+#         Assert(1,v=vorig*t and (M = fail or Morig*t=M),ErrorNoReturn("Hallo 5"));
 #       fi;
 #     od;
 #     # Finally arrange fn component to 0:
@@ -2816,7 +2816,7 @@ end;
 #           M[l,2*n] := M[l,2*n] + M[l,2*n-1] * sc;
 #         od;
 #       fi;
-#       Assert(1,v=vorig*t and (M = fail or Morig*t=M),Error("Hallo 6"));
+#       Assert(1,v=vorig*t and (M = fail or Morig*t=M),ErrorNoReturn("Hallo 6"));
 #     fi;
 #     return t;
 #   end;
@@ -3190,7 +3190,7 @@ FindHomMethodsProjective.ClassicalNatural := function(ri,g)
       if not(IsOne(det)) then
           root := RECOG.ComputeRootInFiniteField(det,gcd.gcd,f);
           if root = fail then
-              Error("Should not have happened, 15634, tell Max!");
+              ErrorNoReturn("Should not have happened, 15634, tell Max!");
           fi;
           gens[i] := gens[i] * root;
           changed := true;

--- a/gap/d247.gi
+++ b/gap/d247.gi
@@ -224,7 +224,7 @@ RECOG.SortOutReducibleNormalSubgroup :=
         fi;
         Info(InfoRecog,2,"D247:Restriction to normal subgroup is homogeneous.");
         if not(MTX.IsAbsolutelyIrreducible(collf[1][1])) then
-            Error("Is this really possible??? G acts absolutely irred!");
+            ErrorNoReturn("Is this really possible??? G acts absolutely irred!");
         fi;
         homs := MTX.Homomorphisms(collf[1][1],m);
         basis := Concatenation(homs);
@@ -241,7 +241,7 @@ RECOG.SortOutReducibleNormalSubgroup :=
         if not(ForAll(kro,k->k[1] = true)) then
             Info(InfoRecog,1,"VERY, VERY, STRANGE!");
             Info(InfoRecog,1,"False alarm, was not a tensor decomposition.");
-            Error("This should never have happened (346), tell Max.");
+            ErrorNoReturn("This should never have happened (346), tell Max.");
         fi;
 
         H := GroupWithGenerators(conjgensG);

--- a/gap/generic/KnownNilpotent.gi
+++ b/gap/generic/KnownNilpotent.gi
@@ -40,8 +40,8 @@ RECOG.DecomposeNilpotent := function(data,el)
   # Now a and b are coprime
   r := Gcdex(a,b);
   if r.gcd <> 1 then
-      Error("<data> corrupt, Product(<data.primesfactor>) and ",
-            "Product(<data.primeskernel>) are not coprime");
+      ErrorNoReturn("<data> corrupt, Product(<data.primesfactor>) and ",
+                    "Product(<data.primeskernel>) are not coprime");
   fi;
   # now r.coeff1 * a + r.coeff2 * b = 1
   # that is, el = el^(r.coeff1 * a) * el^(r.coeff2 * b)

--- a/gap/matrix.gi
+++ b/gap/matrix.gi
@@ -286,7 +286,7 @@ ExtendToBasisOfFullRowspace := function(m,f)
   fi;
   v := ZeroMutable(m[1]);
   if RankMat(m) < Length(m) then
-      Error("No basis!");
+      ErrorNoReturn("No basis!");
   fi;
   i := 1;
   o := One(f);

--- a/gap/perm.gi
+++ b/gap/perm.gi
@@ -189,7 +189,7 @@ end;
 DoSafetyCheckStabChain := function(S)
   while IsBound(S.stabilizer) do
       if not(IsIdenticalObj(S.labels,S.stabilizer.labels)) then
-          Error("Alert! labels not identical on different levels!");
+          ErrorNoReturn("Alert! labels not identical on different levels!");
       fi;
       S := S.stabilizer;
   od;
@@ -333,7 +333,7 @@ StoredPointsPerm := function(p)
   elif IsPerm2Rep(p) then
       return s/2;   # permutation stored with 2 bytes per point
   else
-      Error("StoredPointsPerm: input is not an internal permutation");
+      ErrorNoReturn("StoredPointsPerm: input is not an internal permutation");
   fi;
 end;
 

--- a/gap/ppd.gi
+++ b/gap/ppd.gi
@@ -304,7 +304,6 @@ InstallGlobalFunction( IsPpdElement, function( F, m, d, p, a )
 
     # return if we failed to find one
     if c = false  then
-        #Error("a1");
         return false;
     fi;
 
@@ -321,7 +320,6 @@ InstallGlobalFunction( IsPpdElement, function( F, m, d, p, a )
 
     ## if g is one there is no ppd involved
     if IsOne(g) then
-        #Error("a2");
         return false;
     fi;
 
@@ -332,7 +330,6 @@ InstallGlobalFunction( IsPpdElement, function( F, m, d, p, a )
         ## we know that all primes dividing pm.ppds are large
         ## and hence we know <m> is a large ppd-element
         islarge := true;
-                #Error("a3");
         return [e, islarge];
     fi;
 
@@ -348,13 +345,11 @@ InstallGlobalFunction( IsPpdElement, function( F, m, d, p, a )
     if IsOne(g)  then
         ## (e+1) is the only ppd dividing |<m>| and only once
         islarge := false;
-                #Error("a4");
         return [ e, islarge ];
     else
         ## Either another ppd also divides |<m>| and this one is large or
         ## (e+1)^2 divides |<m>| and hence still large
         islarge := true;
-                #Error("a5");
         return [ e, islarge  ];
     fi;
 

--- a/gap/tensor.gi
+++ b/gap/tensor.gi
@@ -127,7 +127,7 @@ RECOG.FindTensorDecomposition := function(G,N)
       # This will not be reached, since we have made sure that
       # semilinear already caught this. (Lemma: If one tensor factor is
       # semilinear, then the product is.)
-      Error("This should never have happened (1), talk to Max.");
+      ErrorNoReturn("This should never have happened (1), talk to Max.");
   fi;
   # homsimg is a basis of an N-homogenous component.
   # We move that one around with G to find a basis of the natural module:

--- a/makedoc.g
+++ b/makedoc.g
@@ -4,7 +4,7 @@
 ##
 
 if fail = LoadPackage("AutoDoc", ">= 2019.07.03") then
-    Error("AutoDoc 2019.07.03 or newer is required");
+    ErrorNoReturn("AutoDoc 2019.07.03 or newer is required");
 fi;
 
 Read("regen_doc.g");

--- a/regen_doc.g
+++ b/regen_doc.g
@@ -15,9 +15,9 @@ else
                     InputTextNone(), OutputTextNone(),
                     [ GAPInfo.PackagesLoaded.recog[1], "-ef", "." ] );
     if res <> 0 then
-        Error("a different version of recog was already loaded or you ",
-              "started GAP in the wrong directory; try ",
-              "`gap -A regen_doc.g` or `gap -A makedoc.g`");
+        ErrorNoReturn("a different version of recog was already loaded or you ",
+                      "started GAP in the wrong directory; try ",
+                      "`gap -A regen_doc.g` or `gap -A makedoc.g`");
     fi;
 fi;
 

--- a/tst/testsporadicrecog.g
+++ b/tst/testsporadicrecog.g
@@ -6,7 +6,7 @@ TestGroup := function(name,rep,n)
   ag := AtlasGenerators(name,rep);
   g := Group(ag.generators);
   SetSize(g, ag.size);
-  if g = fail then Error("something is wrong with the group"); fi;
+  if g = fail then ErrorNoReturn("something is wrong with the group"); fi;
   r := Runtime();
   l := [];
   for i in [1..n] do


### PR DESCRIPTION
I did this everywhere that I thought appropriate (in particular, I didn't change `misc/` or `contrib/`; I changed most occurrences in `gap/`).

An error is usually triggered when something wrong has happened. `Error` lets you return after this, and continue the computation, which is almost always a bad idea if something genuinely wrong has happened. `ErrorNoReturn` only lets you quit the computation after an error, which seems like the most sensible option in most cases.