### PR TITLE
doc: move parts of the manual into GAPDoc source comments

### DIFF
--- a/doc/afterrecog.xml
+++ b/doc/afterrecog.xml
@@ -70,18 +70,7 @@ methods.
 If you need an element explicitly written in terms of the original
 generators, you can use the following function:
 
-<ManSection>
-<Func Name="SLPforNiceGens" Arg="ri"/>
-<Returns>an SLP expressing the nice generators in the original ones</Returns>
-<Description>
-    This function assembles a possibly quite large straight line program
-    expressing the nice generators in terms of the original ones by using
-    the locally stored information in the recognition tree recursively.<P/>
-    You can concatenate straight line programs in the nice generators with
-    the result of this function to explicitly write an element in terms
-    of the original generators.
-</Description>
-</ManSection>
+<#Include Label="SLPforNiceGens">
 
 <ManSection>
 <Meth Name="\in" Arg="x, ri"/>
@@ -106,17 +95,7 @@ generators, you can use the following function:
 </Description>
 </ManSection>
 
-<ManSection>
-<Func Name="DisplayCompositionFactors" Arg="ri"/>
-<Returns>nothing</Returns>
-<Description>
-    This function displays a composition series by using the recursive
-    recognition tree. It only works, if the usual operation
-    <Ref Oper="CompositionSeries" BookName="ref"/> works for all
-    leaves. THIS DOES CURRENTLY NOT WORK FOR PROJECTIVE GROUPS AND
-    THUS FOR MATRIX GROUPS!
-</Description>
-</ManSection>
+<#Include Label="DisplayCompositionFactors">
 
 </Section>
 

--- a/doc/methsel.xml
+++ b/doc/methsel.xml
@@ -87,18 +87,7 @@ ranks will be descending, but that is not necessary.<P/>
 
 There is one convenience function to put a new method into a method database:
 
-<ManSection>
-<Func Name="AddMethod" Arg="db, meth, rank, stamp [,comment]"/>
-<Returns>nothing</Returns>
-<Description>
-    <A>db</A> must be a method database (list of records, see above) with
-    non-ascending rank values. <A>meth</A> is the method function,
-    <A>rank</A> the rank and <A>stamp</A> a string valued stamp. The
-    optional argument <A>comment</A> can be a string comment. The record
-    describing the method is created and inserted at the correct position
-    in the method database. Nothing is returned.
-</Description>
-</ManSection>
+<#Include Label="AddMethod">
 </Section>
 
 <Section Label="howcalled">
@@ -107,24 +96,7 @@ There is one convenience function to put a new method into a method database:
 Whenever the method selection shall be used, one calls the following
 function:
 
-<ManSection>
-<Func Name="CallMethods" Arg="db, limit [,furtherargs]"/>
-<Returns>a record <C>ms</C> describing this method selection procedure.
-</Returns>
-<Description>
-    The argument <A>db</A> must be a method database in the sense of
-    Section <Ref Sect="whataremethods"/>. <A>limit</A> must be a non-negative
-    integer. <A>furtherargs</A> stands for an arbitrary number of additional
-    arguments, which are handed down to the called methods. Of course they
-    must fulfill the conventions defined for the methods in the database
-    <A>db</A>.<P/>
-    The function first creates a <Q>method selection</Q> record keeping track
-    of the things that happened during the method trying procedure,
-    which is also used during this procedure. Then it calls methods with
-    the algorithm described below and in the end returns the method
-    selection record in its final state.
-</Description>
-</ManSection>
+<#Include Label="CallMethods">
 
 The method selection record has the following components:
 

--- a/doc/recognition.xml
+++ b/doc/recognition.xml
@@ -222,124 +222,17 @@ projective groups, which is stored in the global variable
 </Description>
 </ManSection>
 
-<ManSection>
-<Var Name="FindHomDbPerm"/>
-<Description>
-    This list contains the methods for finding homomorphisms
-    for permutation group recognition that are stored in the record
-    <Ref Var="FindHomMethodsPerm"/>. As described in Section <Ref
-    Sect="whataremethods"/> each method is described by a record. The list
-    is always sorted with respect to decreasing ranks. The order in this
-    list tells in which order the methods should be applied. Use <Ref
-    Func="AddMethod"/> to add methods to this database.
-</Description>
-</ManSection>
-
-<ManSection>
-<Var Name="FindHomMethodsPerm"/>
-<Description>
-    In this global record the functions that are methods for finding
-    homomorphisms for permutation group recognition are stored. We
-    collect them all in this record such that we do not use up too many
-    global variable names.
-</Description>
-</ManSection>
-
-<ManSection>
-<Var Name="SLPforElementFuncsPerm"/>
-<Description>
-    This global record holds the functions that are methods for writing group
-    elements as straight line programs (SLPs) in terms of the generators
-    after successful permutation group recognition. We collect them all in this
-    record such that we do not use up too many global variable names.
-</Description>
-</ManSection>
-
-<ManSection>
-<Var Name="FindHomDbMatrix"/>
-<Description>
-    This list contains the methods for finding homomorphisms
-    for matrix group recognition that are stored in the record
-    <Ref Var="FindHomMethodsMatrix"/>. As described in Section <Ref
-    Sect="whataremethods"/> each method is described by a record. The list
-    is always sorted with respect to decreasing ranks. The order in this
-    list tells in which order the methods should be applied. Use <Ref
-    Func="AddMethod"/> to add methods to this database.
-</Description>
-</ManSection>
-
-<ManSection>
-<Var Name="FindHomMethodsMatrix"/>
-<Description>
-    In this global record the functions that are methods for finding
-    homomorphisms for matrix group recognition are stored. We collect
-    them all in this record such that we do not use up too many global
-    variable names.
-</Description>
-</ManSection>
-
-<ManSection>
-<Var Name="SLPforElementFuncsMatrix"/>
-<Description>
-    This global record holds the functions that are methods for writing group
-    elements as straight line programs (SLPs) in terms of the generators
-    after successful matrix group recognition. We collect them all in this
-    record such that we do not use up too many global variable names.
-</Description>
-</ManSection>
-
-<ManSection>
-<Var Name="FindHomDbProjective"/>
-<Description>
-    This list contains the methods for finding homomorphisms
-    for projective group recognition that are stored in the record
-    <Ref Var="FindHomMethodsProjective"/>. As described in Section <Ref
-    Sect="whataremethods"/> each method is described by a record. The list
-    is always sorted with respect to decreasing ranks. The order in this
-    list tells in which order the methods should be applied. Use <Ref
-    Func="AddMethod"/> to add methods to this database.
-</Description>
-</ManSection>
-
-<ManSection>
-<Var Name="FindHomMethodsProjective"/>
-<Description>
-    In this global record the functions that are methods for finding
-    homomorphisms for projective group recognition are stored. We collect
-    them all in this record such that we do not use up too many global
-    variable names.
-</Description>
-</ManSection>
-
-<ManSection>
-<Var Name="SLPforElementFuncsProjective"/>
-<Description>
-    This global record holds the functions that are methods for writing group
-    elements as straight line programs (SLPs) in terms of the generators
-    after successful projective group recognition. We collect them all in this
-    record such that we do not use up too many global variable names.
-</Description>
-</ManSection>
-
-<ManSection>
-<Var Name="FindHomMethodsGeneric"/>
-<Description>
-    In this global record the functions that are methods for finding
-    homomorphisms for generic group recognition are stored. We
-    collect them all in this record such that we do not use up too many
-    global variable names.
-</Description>
-</ManSection>
-
-<ManSection>
-<Var Name="SLPforElementFuncsGeneric"/>
-<Description>
-    This global record holds the functions that are methods for writing group
-    elements as straight line programs (SLPs) in terms of the generators
-    after successful generic group recognition. We collect them all in this
-    record such that we do not use up too many global variable names.
-</Description>
-</ManSection>
+<#Include Label="FindHomDbPerm">
+<#Include Label="FindHomMethodsPerm">
+<#Include Label="SLPforElementFuncsPerm">
+<#Include Label="FindHomDbMatrix">
+<#Include Label="FindHomMethodsMatrix">
+<#Include Label="SLPforElementFuncsMatrix">
+<#Include Label="FindHomDbProjective">
+<#Include Label="FindHomMethodsProjective">
+<#Include Label="SLPforElementFuncsProjective">
+<#Include Label="FindHomMethodsGeneric">
+<#Include Label="SLPforElementFuncsGeneric">
 
 <ManSection>
 <Func Name="TryFindHomMethod" Arg="H, method, projective"/>
@@ -385,269 +278,34 @@ below. <P/>
 
 The following filters are defined for recognition info records:
 
-<ManSection>
-<Filt Name="IsLeaf" Type="Flag"/>
-<Description>
-This flag indicates, whether or not a recognition info record represents a leaf
-in the recognition tree. If it is not set, one finds at least one of
-the attributes <Ref Attr="RIFac"/> and <Ref Attr="RIKer"/> set for
-the corresponding node. This flag is normally reset and has to be set
-by a find homomorphism method to indicate a leaf.
-</Description>
-</ManSection>
-
-<ManSection>
-<Filt Name="IsReady" Type="Flag"/>
-<Description>
-This flag indicates during the recognition procedure, whether a node in
-the recognition tree is already completed or not. It is mainly set for
-debugging purposes during the recognition. However, if the recognition
-fails somewhere in a leaf, this flag is not set and all nodes above will
-also not have this flag set. In this way one can see whether the recognition
-failed and where the problem was.
-</Description>
-</ManSection>
+<#Include Label="IsLeaf">
+<#Include Label="IsReady">
 
 The following attributes are defined for recognition info records:
 
-<ManSection>
-<Attr Name="Grp" Arg="ri"/>
-<Description>
-The value of this attribute is the group that is to be recognised by this
-recognition info record <A>ri</A>. This attribute is always present during
-recognition and after completion. Note that the generators of the group
-object stored here always have a memory attached to them, such that
-elements that are generated from them remember, how they were acquired.
-</Description>
-</ManSection>
-
-<ManSection>
-<Attr Name="Homom" Arg="ri"/>
-<Description>
-    The value of this attribute is the homomorphism that was found from the
-    group described by the recognition info record <A>ri</A> as a &GAP;
-    object. It is set by a find homomorphism method that succeeded to
-    find a homomorphism (or isomorphism). It does not have to be set
-    in leaf nodes of the recognition tree.
-</Description>
-</ManSection>
-
-<ManSection>
-<Attr Name="NiceGens" Arg="ri"/>
-<Description>
-    The value of this attribute must be set for all nodes and contains
-    the nice generators. The <Ref Func="SLPforElement"/> function of the
-    node will write its straight line program in terms of these nice
-    generators. For leaf nodes, the find homomorphism method is responsible
-    to set the value of <Ref Attr="NiceGens"/>. By default, the original
-    generators of the group at this node are taken. For a homomorphism
-    (or isomorphism), the <Ref Attr="NiceGens"/> will be the concatenation
-    of preimages of the <Ref Attr="NiceGens"/> of the factor group
-    (see <Ref Attr="pregensfac"/>) and
-    the <Ref Attr="NiceGens"/> of the kernel. A find homomorphism method
-    does not have to set <Ref Attr="NiceGens"/> if it finds a homomorphism.
-    Note however, that such a find homomorphism method has to ensure somehow,
-    that preimages of the <Ref Attr="NiceGens"/> of the factor group
-    can be acquired. See <Ref Attr="calcnicegens"/>, <Ref Func="CalcNiceGens"/>
-    and <Ref Attr="slptonice"/>
-    for instructions.
-</Description>
-</ManSection>
-
-<ManSection>
-<Attr Name="pregensfac" Arg="ri"/>
-<Description>
-    The value of this attribute is only set for homomorphism nodes. In that
-    case it contains preimages of the nice generators in the factor group.
-    This attribute is set automatically by the generic recursive recognition
-    function using the mechanism described with the attribute
-    <Ref Attr="calcnicegens"/> below. A find homomorphism does not have
-    to touch this attribute.
-</Description>
-</ManSection>
-
-<ManSection>
-<Attr Name="RIFac" Arg="ri"/>
-<Description>
-    The value of this attribute is the recognition info record of the
-    image of the homomorphism that was found from the group described by
-    the recognition info record <A>ri</A>. It is set by the generic
-    recursive procedure after a find homomorphism method has succeeded
-    to find a homomorphism (or isomorphism). It does not have to be set
-    in leaf nodes of the recognition tree. This attribute value provides
-    the link to the <Q>factor</Q> subtree of the recognition tree.
-</Description>
-</ManSection>
-
-<ManSection>
-<Attr Name="RIKer" Arg="ri"/>
-<Description>
-    The value of this attribute is the recognition info record of the
-    kernel of the homomorphism that was found from the group described by
-    the recognition info record <A>ri</A>. It is set by the generic
-    recursive procedure after a find homomorphism method has succeeded
-    to find a homomorphism (or isomorphism). It does not have to be set
-    in leaf nodes of the recognition tree or if the homomorphism is known to
-    be an isomorphism. In the latter case the value of the attribute is
-    set to <K>fail</K>. This attribute value provides the link to the
-    <Q>kernel</Q> subtree of the recognition tree.
-</Description>
-</ManSection>
-
-<ManSection>
-<Attr Name="RIParent" Arg="ri"/>
-<Description>
-    The value of this attribute is the recognition info record of the
-    parent of this node in the recognition tree. The top node does not
-    have this attribute set.
-</Description>
-</ManSection>
-
-<ManSection>
-<Attr Name="fhmethsel" Arg="ri"/>
-<Description>
-    The value of this attribute is the record returned by the method
-    selection (see Section <Ref Sect="howcalled"/>) after it ran to
-    find a homomorphism (or isomorphism). It is there to be able to see
-    which methods were tried until the recognition of the node was
-    completed.
-</Description>
-</ManSection>
-
-<ManSection>
-<Attr Name="slpforelement" Arg="ri"/>
-<Description>
-    After the recognition phase is completed for the node <A>ri</A>, we
-    are by definition able to write arbitrary elements in the group described
-    by this node as a straight line program (SLP) in terms of the nice
-    generators stored in <Ref Attr="NiceGens"/>.
-    This attribute value is a function taking the node <A>ri</A> and a
-    group element as its arguments and returning the above mentioned
-    straight line program. For the case that a find homomorphism method
-    succeeds in finding a homomorphism, the generic recursive function
-    sets this attribute to the function <Ref Func="SLPforElementGeneric"/>
-    which does the job for the generic homomorphism situation. In all other
-    cases the successful find homomorphism method has to set this attribute
-    to a function doing the job. The find homomorphism method is free to
-    store additional data in the recognition info record or the group
-    object such that the <Ref Func="SLPforElement"/> function can work.
-</Description>
-</ManSection>
-
-<ManSection>
-<Func Name="SLPforElement" Arg="ri, x"/>
-<Returns>a straight line program expressing <A>x</A> in the nice generators.
-</Returns>
-<Description>
-    This is a wrapper function which extracts the value of the attribute
-    <Ref Attr="slpforelement"/> and calls that function with the arguments
-    <A>ri</A> and <A>x</A>.
-</Description>
-</ManSection>
-
-<ManSection>
-<Attr Name="StdPresentation" Arg="ri"/>
-<Description>
-    After the verification phase, the presentation is stored here. Details
-    have still to be decided upon.
-</Description>
-</ManSection>
-
-<ManSection>
-<Attr Name="methodsforfactor" Arg="ri"/>
-<Description>
-    This attribute is initialised at the beginning of the recursive
-    recognition function with the database of find homomorphism methods
-    that was used to recognise the group corresponding to the
-    recognition info record <A>ri</A>. If the found homomorphism
-    changes the representation of the group (going for example from
-    a matrix group to a permutation group), the find homomorphism method
-    can report this by exchanging the database of find homomorphism methods
-    to be used in the recognition of the image of the homomorphism by
-    setting the value of this attribute to something different. It lies
-    in the responsibility of the find homomorphism method to do so,
-    if the representation changes through the homomorphism.
-</Description>
-</ManSection>
+<#Include Label="Grp">
+<#Include Label="Homom">
+<#Include Label="NiceGens">
+<#Include Label="pregensfac">
+<#Include Label="RIFac">
+<#Include Label="RIKer">
+<#Include Label="RIParent">
+<#Include Label="fhmethsel">
+<#Include Label="slpforelement">
+<#Include Label="SLPforElement">
+<#Include Label="StdPresentation">
+<#Include Label="methodsforfactor">
 
 The following two attributes are concerned with the relation between
 the original generators and the nice generators for a node.
 They are used to transport this information from a successful find
 homomorphism method up to the recursive recognition function:
 
-<ManSection>
-<Attr Name="calcnicegens" Arg="ri"/>
-<Description>
-    To make the recursion work, we have to acquire preimages of the
-    nice generators in factor groups under the homomorphism found.
-    But we want to keep the information, how the nice generators
-    were found, locally at the node where they were found. This
-    attribute solves this problem of acquiring preimages in the following
-    way: Its value must be a function, taking the recognition info
-    record <A>ri</A> as first argument, and a list <A>origgens</A> of
-    preimages of the
-    original generators of the current node, and has to
-    return corresponding preimages of the nice generators. Usually this
-    task can be done by storing a straight line program writing the
-    nice generators in terms of the original generators and executing
-    this with inputs <A>origgens</A>. Therefore the default value of
-    this attribute is the function <Ref Func="CalcNiceGensGeneric"/>
-    described below.
-</Description>
-</ManSection>
-
-<ManSection>
-<Func Name="CalcNiceGensGeneric" Arg="ri, origgens"/>
-<Returns>a list of preimages of the nice generators</Returns>
-<Description>
-    This is the default function for leaf nodes for the attribute <Ref
-    Attr="calcnicegens"/> described above. It does the following: If the
-    value of the attribute <Ref Attr="slptonice"/> is set, then it must
-    be a straight line program expressing the nice generators in terms
-    of the original generators of this node. In that case, this straight
-    line program is executed with <A>origgens</A> as inputs and the
-    result is returned. Otherwise, <A>origgens</A> is returned as is.
-    Therefore a leaf node just has to do nothing if the nice generators
-    are equal to the original generators, or can simply store the right
-    straight line program into the attribute <Ref Attr="slptonice"/> to
-    fulfill its duties.
-</Description>
-</ManSection>
-
-<ManSection>
-<Func Name="CalcNiceGensHomNode" Arg="ri, origgens"/>
-<Returns>a list of preimages of the nice generators</Returns>
-<Description>
-    This is the default function for homomorphism node for the attribute
-    <Ref Attr="calcnicegens"/>. It just delegates to factor and kernel of
-    the homomorphism, as the nice generators of a homomorphism (or isomorphism)
-    node are just the concatenation of the nice generators of the factor
-    and the kernel. A find homomorphism method finding a homomorphism
-    or isomorphism does not have to do anything with respect to nice
-    generators.
-</Description>
-</ManSection>
-
-<ManSection>
-<Func Name="CalcNiceGens" Arg="ri, origgens"/>
-<Returns>a list of preimages of the nice generators</Returns>
-<Description>
-    This is a wrapper function which extracts the value of the attribute
-    <Ref Attr="calcnicegens"/> and calls that function with the arguments
-    <A>ri</A> and <A>origgens</A>.
-</Description>
-</ManSection>
-
-<ManSection>
-<Attr Name="slptonice" Arg="ri"/>
-<Description>
-    As described above, the value, if set, must be a straight line program
-    expressing the nice generators at this node in terms of the original
-    generators. This is for leaf nodes, that choose to use the default
-    function <Ref Func="CalcNiceGensGeneric"/> installed in the
-    <Ref Attr="calcnicegens"/> attribute.
-</Description>
-</ManSection>
+<#Include Label="calcnicegens">
+<#Include Label="CalcNiceGensGeneric">
+<#Include Label="CalcNiceGensHomNode">
+<#Include Label="CalcNiceGens">
+<#Include Label="slptonice">
 
 The following three attributes are concerned with the administration of the
 kernel of a found homomorphism. Find homomorphism methods use them to

--- a/gap/almostsimple.gi
+++ b/gap/almostsimple.gi
@@ -131,8 +131,8 @@ InstallGlobalFunction( DoHintedStabChain, function(ri,G,hint)
         return fail;
     fi;
     stdgens := stdgens.gens;
-    Setslptostd(ri,SLPOfElms(stdgens));
-    SetStdGens(ri,StripMemory(stdgens));
+    #Setslptostd(ri,SLPOfElms(stdgens));
+    #SetStdGens(ri,StripMemory(stdgens));
     if IsBound(hint.usemax) then
         if IsBound(hint.brauercharelm) then
             elm := ResultOfStraightLineProgram(hint.brauercharelm,stdgens);

--- a/gap/base/methsel.gd
+++ b/gap/base/methsel.gd
@@ -20,7 +20,43 @@
 
 DeclareInfoClass( "InfoMethSel" );
 SetInfoLevel(InfoMethSel,1);
+
+## <#GAPDoc Label="AddMethod">
+## <ManSection>
+## <Func Name="AddMethod" Arg="db, meth, rank, stamp [,comment]"/>
+## <Returns>nothing</Returns>
+## <Description>
+##     <A>db</A> must be a method database (list of records, see above) with
+##     non-ascending rank values. <A>meth</A> is the method function,
+##     <A>rank</A> the rank and <A>stamp</A> a string valued stamp. The
+##     optional argument <A>comment</A> can be a string comment. The record
+##     describing the method is created and inserted at the correct position
+##     in the method database. Nothing is returned.
+## </Description>
+## </ManSection>
+## <#/GAPDoc>
 DeclareGlobalFunction( "AddMethod" );
+
+## <#GAPDoc Label="CallMethods">
+## <ManSection>
+## <Func Name="CallMethods" Arg="db, limit [,furtherargs]"/>
+## <Returns>a record <C>ms</C> describing this method selection procedure.
+## </Returns>
+## <Description>
+##     The argument <A>db</A> must be a method database in the sense of
+##     Section <Ref Sect="whataremethods"/>. <A>limit</A> must be a non-negative
+##     integer. <A>furtherargs</A> stands for an arbitrary number of additional
+##     arguments, which are handed down to the called methods. Of course they
+##     must fulfill the conventions defined for the methods in the database
+##     <A>db</A>.<P/>
+##     The function first creates a <Q>method selection</Q> record keeping track
+##     of the things that happened during the method trying procedure,
+##     which is also used during this procedure. Then it calls methods with
+##     the algorithm described below and in the end returns the method
+##     selection record in its final state.
+## </Description>
+## </ManSection>
+## <#/GAPDoc>
 DeclareGlobalFunction( "CallMethods" );
 
 

--- a/gap/base/recognition.gd
+++ b/gap/base/recognition.gd
@@ -37,26 +37,258 @@ fi;
 BindGlobal( "RECOG", rec() );
 
 # Some properties and attributes of the recognition infos:
+
+## <#GAPDoc Label="IsLeaf">
+## <ManSection>
+## <Filt Name="IsLeaf" Type="Flag"/>
+## <Description>
+## This flag indicates, whether or not a recognition info record represents a leaf
+## in the recognition tree. If it is not set, one finds at least one of
+## the attributes <Ref Attr="RIFac"/> and <Ref Attr="RIKer"/> set for
+## the corresponding node. This flag is normally reset and has to be set
+## by a find homomorphism method to indicate a leaf.
+## </Description>
+## </ManSection>
+## <#/GAPDoc>
 DeclareFilter( "IsLeaf" );
+
+## <#GAPDoc Label="IsReady">
+## <ManSection>
+## <Filt Name="IsReady" Type="Flag"/>
+## <Description>
+## This flag indicates during the recognition procedure, whether a node in
+## the recognition tree is already completed or not. It is mainly set for
+## debugging purposes during the recognition. However, if the recognition
+## fails somewhere in a leaf, this flag is not set and all nodes above will
+## also not have this flag set. In this way one can see whether the recognition
+## failed and where the problem was.
+## </Description>
+## </ManSection>
+## <#/GAPDoc>
 DeclareFilter( "IsReady" );
+
+## <#GAPDoc Label="Grp">
+## <ManSection>
+## <Attr Name="Grp" Arg="ri"/>
+## <Description>
+## The value of this attribute is the group that is to be recognised by this
+## recognition info record <A>ri</A>. This attribute is always present during
+## recognition and after completion. Note that the generators of the group
+## object stored here always have a memory attached to them, such that
+## elements that are generated from them remember, how they were acquired.
+## </Description>
+## </ManSection>
+## <#/GAPDoc>
 DeclareAttribute( "Grp", IsRecognitionInfo, "mutable" );
+
+## <#GAPDoc Label="Homom">
+## <ManSection>
+## <Attr Name="Homom" Arg="ri"/>
+## <Description>
+##     The value of this attribute is the homomorphism that was found from the
+##     group described by the recognition info record <A>ri</A> as a &GAP;
+##     object. It is set by a find homomorphism method that succeeded to
+##     find a homomorphism (or isomorphism). It does not have to be set
+##     in leaf nodes of the recognition tree.
+## </Description>
+## </ManSection>
+## <#/GAPDoc>
 DeclareAttribute( "Homom", IsRecognitionInfo, "mutable" );
-DeclareAttribute( "StdGens", IsRecognitionInfo, "mutable" );    # TODO: implement
+
+## <#GAPDoc Label="NiceGens">
+## <ManSection>
+## <Attr Name="NiceGens" Arg="ri"/>
+## <Description>
+##     The value of this attribute must be set for all nodes and contains
+##     the nice generators. The <Ref Func="SLPforElement"/> function of the
+##     node will write its straight line program in terms of these nice
+##     generators. For leaf nodes, the find homomorphism method is responsible
+##     to set the value of <Ref Attr="NiceGens"/>. By default, the original
+##     generators of the group at this node are taken. For a homomorphism
+##     (or isomorphism), the <Ref Attr="NiceGens"/> will be the concatenation
+##     of preimages of the <Ref Attr="NiceGens"/> of the factor group
+##     (see <Ref Attr="pregensfac"/>) and
+##     the <Ref Attr="NiceGens"/> of the kernel. A find homomorphism method
+##     does not have to set <Ref Attr="NiceGens"/> if it finds a homomorphism.
+##     Note however, that such a find homomorphism method has to ensure somehow,
+##     that preimages of the <Ref Attr="NiceGens"/> of the factor group
+##     can be acquired. See <Ref Attr="calcnicegens"/>, <Ref Func="CalcNiceGens"/>
+##     and <Ref Attr="slptonice"/>
+##     for instructions.
+## </Description>
+## </ManSection>
+## <#/GAPDoc>
 DeclareAttribute( "NiceGens", IsRecognitionInfo, "mutable" );
+
+## <#GAPDoc Label="RIFac">
+## <ManSection>
+## <Attr Name="RIFac" Arg="ri"/>
+## <Description>
+##     The value of this attribute is the recognition info record of the
+##     image of the homomorphism that was found from the group described by
+##     the recognition info record <A>ri</A>. It is set by the generic
+##     recursive procedure after a find homomorphism method has succeeded
+##     to find a homomorphism (or isomorphism). It does not have to be set
+##     in leaf nodes of the recognition tree. This attribute value provides
+##     the link to the <Q>factor</Q> subtree of the recognition tree.
+## </Description>
+## </ManSection>
+## <#/GAPDoc>
 DeclareAttribute( "RIFac", IsRecognitionInfo, "mutable" );
+
+## <#GAPDoc Label="RIKer">
+## <ManSection>
+## <Attr Name="RIKer" Arg="ri"/>
+## <Description>
+##     The value of this attribute is the recognition info record of the
+##     kernel of the homomorphism that was found from the group described by
+##     the recognition info record <A>ri</A>. It is set by the generic
+##     recursive procedure after a find homomorphism method has succeeded
+##     to find a homomorphism (or isomorphism). It does not have to be set
+##     in leaf nodes of the recognition tree or if the homomorphism is known to
+##     be an isomorphism. In the latter case the value of the attribute is
+##     set to <K>fail</K>. This attribute value provides the link to the
+##     <Q>kernel</Q> subtree of the recognition tree.
+## </Description>
+## </ManSection>
+## <#/GAPDoc>
 DeclareAttribute( "RIKer", IsRecognitionInfo, "mutable" );
+
+## <#GAPDoc Label="RIParent">
+## <ManSection>
+## <Attr Name="RIParent" Arg="ri"/>
+## <Description>
+##     The value of this attribute is the recognition info record of the
+##     parent of this node in the recognition tree. The top node does not
+##     have this attribute set.
+## </Description>
+## </ManSection>
+## <#/GAPDoc>
 DeclareAttribute( "RIParent", IsRecognitionInfo, "mutable" );
+
+## <#GAPDoc Label="StdPresentation">
+## <ManSection>
+## <Attr Name="StdPresentation" Arg="ri"/>
+## <Description>
+##     After the verification phase, the presentation is stored here. Details
+##     have still to be decided upon.
+## </Description>
+## </ManSection>
+## <#/GAPDoc>
 DeclareAttribute( "StdPresentation", IsRecognitionInfo, "mutable" );    # TODO: implement
+
 DeclareProperty( "IsRecogInfoForSimpleGroup", IsRecognitionInfo );
 DeclareProperty( "IsRecogInfoForAlmostSimpleGroup", IsRecognitionInfo );
 InstallTrueMethod( IsRecogInfoForAlmostSimpleGroup, IsRecogInfoForSimpleGroup );
 
+## <#GAPDoc Label="pregensfac">
+## <ManSection>
+## <Attr Name="pregensfac" Arg="ri"/>
+## <Description>
+##     The value of this attribute is only set for homomorphism nodes. In that
+##     case it contains preimages of the nice generators in the factor group.
+##     This attribute is set automatically by the generic recursive recognition
+##     function using the mechanism described with the attribute
+##     <Ref Attr="calcnicegens"/> below. A find homomorphism does not have
+##     to touch this attribute.
+## </Description>
+## </ManSection>
+## <#/GAPDoc>
 DeclareAttribute( "pregensfac", IsRecognitionInfo, "mutable" );
+
+## <#GAPDoc Label="calcnicegens">
+## <ManSection>
+## <Attr Name="calcnicegens" Arg="ri"/>
+## <Description>
+##     To make the recursion work, we have to acquire preimages of the
+##     nice generators in factor groups under the homomorphism found.
+##     But we want to keep the information, how the nice generators
+##     were found, locally at the node where they were found. This
+##     attribute solves this problem of acquiring preimages in the following
+##     way: Its value must be a function, taking the recognition info
+##     record <A>ri</A> as first argument, and a list <A>origgens</A> of
+##     preimages of the
+##     original generators of the current node, and has to
+##     return corresponding preimages of the nice generators. Usually this
+##     task can be done by storing a straight line program writing the
+##     nice generators in terms of the original generators and executing
+##     this with inputs <A>origgens</A>. Therefore the default value of
+##     this attribute is the function <Ref Func="CalcNiceGensGeneric"/>
+##     described below.
+## </Description>
+## </ManSection>
+## <#/GAPDoc>
 DeclareAttribute( "calcnicegens", IsRecognitionInfo, "mutable" );
+
+## <#GAPDoc Label="slptonice">
+## <ManSection>
+## <Attr Name="slptonice" Arg="ri"/>
+## <Description>
+##     As described above, the value, if set, must be a straight line program
+##     expressing the nice generators at this node in terms of the original
+##     generators. This is for leaf nodes, that choose to use the default
+##     function <Ref Func="CalcNiceGensGeneric"/> installed in the
+##     <Ref Attr="calcnicegens"/> attribute.
+## </Description>
+## </ManSection>
+## <#/GAPDoc>
 DeclareAttribute( "slptonice", IsRecognitionInfo, "mutable" );
-DeclareAttribute( "slptostd", IsRecognitionInfo, "mutable" );
+
+## <#GAPDoc Label="fhmethsel">
+## <ManSection>
+## <Attr Name="fhmethsel" Arg="ri"/>
+## <Description>
+##     The value of this attribute is the record returned by the method
+##     selection (see Section <Ref Sect="howcalled"/>) after it ran to
+##     find a homomorphism (or isomorphism). It is there to be able to see
+##     which methods were tried until the recognition of the node was
+##     completed.
+## </Description>
+## </ManSection>
+## <#/GAPDoc>
 DeclareAttribute( "fhmethsel", IsRecognitionInfo, "mutable" );      # TODO: rename?
+
+## <#GAPDoc Label="methodsforfactor">
+## <ManSection>
+## <Attr Name="methodsforfactor" Arg="ri"/>
+## <Description>
+##     This attribute is initialised at the beginning of the recursive
+##     recognition function with the database of find homomorphism methods
+##     that was used to recognise the group corresponding to the
+##     recognition info record <A>ri</A>. If the found homomorphism
+##     changes the representation of the group (going for example from
+##     a matrix group to a permutation group), the find homomorphism method
+##     can report this by exchanging the database of find homomorphism methods
+##     to be used in the recognition of the image of the homomorphism by
+##     setting the value of this attribute to something different. It lies
+##     in the responsibility of the find homomorphism method to do so,
+##     if the representation changes through the homomorphism.
+## </Description>
+## </ManSection>
+## <#/GAPDoc>
 DeclareAttribute( "methodsforfactor", IsRecognitionInfo, "mutable" ); # rename to MethodsDBForFactor
+
+## <#GAPDoc Label="slpforelement">
+## <ManSection>
+## <Attr Name="slpforelement" Arg="ri"/>
+## <Description>
+##     After the recognition phase is completed for the node <A>ri</A>, we
+##     are by definition able to write arbitrary elements in the group described
+##     by this node as a straight line program (SLP) in terms of the nice
+##     generators stored in <Ref Attr="NiceGens"/>.
+##     This attribute value is a function taking the node <A>ri</A> and a
+##     group element as its arguments and returning the above mentioned
+##     straight line program. For the case that a find homomorphism method
+##     succeeds in finding a homomorphism, the generic recursive function
+##     sets this attribute to the function <Ref Func="SLPforElementGeneric"/>
+##     which does the job for the generic homomorphism situation. In all other
+##     cases the successful find homomorphism method has to set this attribute
+##     to a function doing the job. The find homomorphism method is free to
+##     store additional data in the recognition info record or the group
+##     object such that the <Ref Func="SLPforElement"/> function can work.
+## </Description>
+## </ManSection>
+## <#/GAPDoc>
 DeclareAttribute( "slpforelement", IsRecognitionInfo, "mutable" );
 # Here we collect generators of the kernel:
 DeclareAttribute( "gensN", IsRecognitionInfo, "mutable" );      # TODO: rename?
@@ -84,20 +316,157 @@ DeclareAttribute( "order", IsRecognitionInfo, "mutable" );
 # Some variables to hold databases of methods and such things:
 #############################################################################
 
-BindGlobal( "FindHomMethodsPerm", rec() );
-BindGlobal( "SLPforElementFuncsPerm", rec() );
-BindGlobal( "FindHomDbPerm", [] );
+## <#GAPDoc Label="FindHomMethodsPerm">
+## <ManSection>
+## <Var Name="FindHomMethodsPerm"/>
+## <Description>
+##     In this global record the functions that are methods for finding
+##     homomorphisms for permutation group recognition are stored. We
+##     collect them all in this record such that we do not use up too many
+##     global variable names.
+## </Description>
+## </ManSection>
+## <#/GAPDoc>
+DeclareGlobalVariable( "FindHomMethodsPerm" );
 
-BindGlobal( "FindHomMethodsMatrix", rec() );
-BindGlobal( "SLPforElementFuncsMatrix", rec() );
-BindGlobal( "FindHomDbMatrix", [] );
+## <#GAPDoc Label="SLPforElementFuncsPerm">
+## <ManSection>
+## <Var Name="SLPforElementFuncsPerm"/>
+## <Description>
+##     This global record holds the functions that are methods for writing group
+##     elements as straight line programs (SLPs) in terms of the generators
+##     after successful permutation group recognition. We collect them all in this
+##     record such that we do not use up too many global variable names.
+## </Description>
+## </ManSection>
+## <#/GAPDoc>
+DeclareGlobalVariable( "SLPforElementFuncsPerm" );
 
-BindGlobal( "FindHomMethodsProjective", rec() );
-BindGlobal( "SLPforElementFuncsProjective", rec() );
-BindGlobal( "FindHomDbProjective", [] );
+## <#GAPDoc Label="FindHomDbPerm">
+## <ManSection>
+## <Var Name="FindHomDbPerm"/>
+## <Description>
+##     This list contains the methods for finding homomorphisms
+##     for permutation group recognition that are stored in the record
+##     <Ref Var="FindHomMethodsPerm"/>. As described in Section <Ref
+##     Sect="whataremethods"/> each method is described by a record. The list
+##     is always sorted with respect to decreasing ranks. The order in this
+##     list tells in which order the methods should be applied. Use <Ref
+##     Func="AddMethod"/> to add methods to this database.
+## </Description>
+## </ManSection>
+## <#/GAPDoc>
+DeclareGlobalVariable( "FindHomDbPerm" );
 
-BindGlobal( "FindHomMethodsGeneric", rec() );
-BindGlobal( "SLPforElementFuncsGeneric", rec() );
+## <#GAPDoc Label="FindHomMethodsMatrix">
+## <ManSection>
+## <Var Name="FindHomMethodsMatrix"/>
+## <Description>
+##     In this global record the functions that are methods for finding
+##     homomorphisms for matrix group recognition are stored. We collect
+##     them all in this record such that we do not use up too many global
+##     variable names.
+## </Description>
+## </ManSection>
+## <#/GAPDoc>
+DeclareGlobalVariable( "FindHomMethodsMatrix" );
+
+## <#GAPDoc Label="SLPforElementFuncsMatrix">
+## <ManSection>
+## <Var Name="SLPforElementFuncsMatrix"/>
+## <Description>
+##     This global record holds the functions that are methods for writing group
+##     elements as straight line programs (SLPs) in terms of the generators
+##     after successful matrix group recognition. We collect them all in this
+##     record such that we do not use up too many global variable names.
+## </Description>
+## </ManSection>
+## <#/GAPDoc>
+DeclareGlobalVariable( "SLPforElementFuncsMatrix" );
+
+## <#GAPDoc Label="FindHomDbMatrix">
+## <ManSection>
+## <Var Name="FindHomDbMatrix"/>
+## <Description>
+##     This list contains the methods for finding homomorphisms
+##     for matrix group recognition that are stored in the record
+##     <Ref Var="FindHomMethodsMatrix"/>. As described in Section <Ref
+##     Sect="whataremethods"/> each method is described by a record. The list
+##     is always sorted with respect to decreasing ranks. The order in this
+##     list tells in which order the methods should be applied. Use <Ref
+##     Func="AddMethod"/> to add methods to this database.
+## </Description>
+## </ManSection>
+## <#/GAPDoc>
+DeclareGlobalVariable( "FindHomDbMatrix" );
+
+## <#GAPDoc Label="FindHomMethodsProjective">
+## <ManSection>
+## <Var Name="FindHomMethodsProjective"/>
+## <Description>
+##     In this global record the functions that are methods for finding
+##     homomorphisms for projective group recognition are stored. We collect
+##     them all in this record such that we do not use up too many global
+##     variable names.
+## </Description>
+## </ManSection>
+## <#/GAPDoc>
+DeclareGlobalVariable( "FindHomMethodsProjective" );
+
+## <#GAPDoc Label="SLPforElementFuncsProjective">
+## <ManSection>
+## <Var Name="SLPforElementFuncsProjective"/>
+## <Description>
+##     This global record holds the functions that are methods for writing group
+##     elements as straight line programs (SLPs) in terms of the generators
+##     after successful projective group recognition. We collect them all in this
+##     record such that we do not use up too many global variable names.
+## </Description>
+## </ManSection>
+## <#/GAPDoc>
+DeclareGlobalVariable( "SLPforElementFuncsProjective" );
+
+## <#GAPDoc Label="FindHomDbProjective">
+## <ManSection>
+## <Var Name="FindHomDbProjective"/>
+## <Description>
+##     This list contains the methods for finding homomorphisms
+##     for projective group recognition that are stored in the record
+##     <Ref Var="FindHomMethodsProjective"/>. As described in Section <Ref
+##     Sect="whataremethods"/> each method is described by a record. The list
+##     is always sorted with respect to decreasing ranks. The order in this
+##     list tells in which order the methods should be applied. Use <Ref
+##     Func="AddMethod"/> to add methods to this database.
+## </Description>
+## </ManSection>
+## <#/GAPDoc>
+DeclareGlobalVariable( "FindHomDbProjective" );
+
+## <#GAPDoc Label="FindHomMethodsGeneric">
+## <ManSection>
+## <Var Name="FindHomMethodsGeneric"/>
+## <Description>
+##     In this global record the functions that are methods for finding
+##     homomorphisms for generic group recognition are stored. We
+##     collect them all in this record such that we do not use up too many
+##     global variable names.
+## </Description>
+## </ManSection>
+## <#/GAPDoc>
+DeclareGlobalVariable( "FindHomMethodsGeneric" );
+
+## <#GAPDoc Label="SLPforElementFuncsGeneric">
+## <ManSection>
+## <Var Name="SLPforElementFuncsGeneric"/>
+## <Description>
+##     This global record holds the functions that are methods for writing group
+##     elements as straight line programs (SLPs) in terms of the generators
+##     after successful generic group recognition. We collect them all in this
+##     record such that we do not use up too many global variable names.
+## </Description>
+## </ManSection>
+## <#/GAPDoc>
+DeclareGlobalVariable( "SLPforElementFuncsGeneric" );
 
 
 # Our global functions for the main recursion:
@@ -119,10 +488,70 @@ DeclareGlobalFunction( "TryFindHomMethod" );
 
 # Helper functions for the generic part:
 
+## <#GAPDoc Label="CalcNiceGens">
+## <ManSection>
+## <Func Name="CalcNiceGens" Arg="ri, origgens"/>
+## <Returns>a list of preimages of the nice generators</Returns>
+## <Description>
+##     This is a wrapper function which extracts the value of the attribute
+##     <Ref Attr="calcnicegens"/> and calls that function with the arguments
+##     <A>ri</A> and <A>origgens</A>.
+## </Description>
+## </ManSection>
+## <#/GAPDoc>
 DeclareGlobalFunction( "CalcNiceGens" );
+
+## <#GAPDoc Label="CalcNiceGensGeneric">
+## <ManSection>
+## <Func Name="CalcNiceGensGeneric" Arg="ri, origgens"/>
+## <Returns>a list of preimages of the nice generators</Returns>
+## <Description>
+##     This is the default function for leaf nodes for the attribute <Ref
+##     Attr="calcnicegens"/> described above. It does the following: If the
+##     value of the attribute <Ref Attr="slptonice"/> is set, then it must
+##     be a straight line program expressing the nice generators in terms
+##     of the original generators of this node. In that case, this straight
+##     line program is executed with <A>origgens</A> as inputs and the
+##     result is returned. Otherwise, <A>origgens</A> is returned as is.
+##     Therefore a leaf node just has to do nothing if the nice generators
+##     are equal to the original generators, or can simply store the right
+##     straight line program into the attribute <Ref Attr="slptonice"/> to
+##     fulfill its duties.
+## </Description>
+## </ManSection>
+## <#/GAPDoc>
 DeclareGlobalFunction( "CalcNiceGensGeneric" );
+
+## <#GAPDoc Label="CalcNiceGensHomNode">
+## <ManSection>
+## <Func Name="CalcNiceGensHomNode" Arg="ri, origgens"/>
+## <Returns>a list of preimages of the nice generators</Returns>
+## <Description>
+##     This is the default function for homomorphism node for the attribute
+##     <Ref Attr="calcnicegens"/>. It just delegates to factor and kernel of
+##     the homomorphism, as the nice generators of a homomorphism (or isomorphism)
+##     node are just the concatenation of the nice generators of the factor
+##     and the kernel. A find homomorphism method finding a homomorphism
+##     or isomorphism does not have to do anything with respect to nice
+##     generators.
+## </Description>
+## </ManSection>
+## <#/GAPDoc>
 DeclareGlobalFunction( "CalcNiceGensHomNode" );
 DeclareGlobalFunction( "SLPforElementGeneric" );
+
+## <#GAPDoc Label="SLPforElement">
+## <ManSection>
+## <Func Name="SLPforElement" Arg="ri, x"/>
+## <Returns>a straight line program expressing <A>x</A> in the nice generators.
+## </Returns>
+## <Description>
+##     This is a wrapper function which extracts the value of the attribute
+##     <Ref Attr="slpforelement"/> and calls that function with the arguments
+##     <A>ri</A> and <A>x</A>.
+## </Description>
+## </ManSection>
+## <#/GAPDoc>
 DeclareGlobalFunction( "SLPforElement" );
 DeclareGlobalFunction( "RandomSubproduct" );
 DeclareGlobalFunction( "FastNormalClosure" );
@@ -148,5 +577,35 @@ DeclareGlobalFunction( "VerifyGroup" );
 
 # Some more user functions:
 
+## <#GAPDoc Label="DisplayCompositionFactors">
+## <ManSection>
+## <Func Name="DisplayCompositionFactors" Arg="ri"/>
+## <Returns>nothing</Returns>
+## <Description>
+##     This function displays a composition series by using the recursive
+##     recognition tree. It only works, if the usual operation
+##     <Ref Oper="CompositionSeries" BookName="ref"/> works for all
+##     leaves. THIS DOES CURRENTLY NOT WORK FOR PROJECTIVE GROUPS AND
+##     THUS FOR MATRIX GROUPS!
+## </Description>
+## </ManSection>
+## <#/GAPDoc>
 DeclareGlobalFunction( "DisplayCompositionFactors" );
+
+## <#GAPDoc Label="SLPforNiceGens">
+## <ManSection>
+## <Func Name="SLPforNiceGens" Arg="ri"/>
+## <Returns>an SLP expressing the nice generators in the original ones</Returns>
+## <Description>
+##     This function assembles a possibly quite large straight line program
+##     expressing the nice generators in terms of the original ones by using
+##     the locally stored information in the recognition tree recursively.<P/>
+##     You can concatenate straight line programs in the nice generators with
+##     the result of this function to explicitly write an element in terms
+##     of the original generators.
+## </Description>
+## </ManSection>
+## <#/GAPDoc>
+DeclareGlobalFunction( "SLPforNiceGens" );
+
 DeclareGlobalFunction( "GetCompositionTreeNode" );

--- a/gap/base/recognition.gi
+++ b/gap/base/recognition.gi
@@ -30,6 +30,22 @@ InstallValue( RecognitionInfoType,
 # Objectify(RecognitionInfoType,r);
 
 
+InstallValue( FindHomMethodsPerm, rec() );
+InstallValue( SLPforElementFuncsPerm, rec() );
+InstallValue( FindHomDbPerm, [] );
+
+InstallValue( FindHomMethodsMatrix, rec() );
+InstallValue( SLPforElementFuncsMatrix, rec() );
+InstallValue( FindHomDbMatrix, [] );
+
+InstallValue( FindHomMethodsProjective, rec() );
+InstallValue( SLPforElementFuncsProjective, rec() );
+InstallValue( FindHomDbProjective, [] );
+
+InstallValue( FindHomMethodsGeneric, rec() );
+InstallValue( SLPforElementFuncsGeneric, rec() );
+
+
 # a nice view method:
 RECOG_ViewObj := function( level, ri )
     local ms;
@@ -940,7 +956,7 @@ InstallGlobalFunction( "DisplayCompositionFactors", function(arg)
   fi;
 end );
 
-BindGlobal( "SLPforNiceGens", function(ri)
+InstallGlobalFunction( "SLPforNiceGens", function(ri)
   local l,ll,s;
   l := List( [1..Length(GeneratorsOfGroup(Grp(ri)))], x->() );
   l := GeneratorsWithMemory(l);


### PR DESCRIPTION
The other manpages should also be moved into GAPDoc comments;
and these then in turn could be converted to AutoDoc comments.
But for now, this is a start and could serve as template for
others who might want to help.