### PR TITLE
Make the documentation compile again: change a tag </P> -> <P/>

### DIFF
--- a/doc/recognition.xml
+++ b/doc/recognition.xml
@@ -315,7 +315,7 @@ The function must return a boolean. If it returns <K>false</K>, then
 this means that <A>x</A> is not in the source of the homomorphism
 returned by <Ref Attr="Homom"/>. If <K>true</K> is returned, then
 either <A>x</A> is in the source of that homomorphism, or passing
-<A>x</A> to the homomorphism returns <K>fail</K>.</P>
+<A>x</A> to the homomorphism returns <K>fail</K>.<P/>
 
 For example,
 if <A>ri</A> represents a matrix group that preserves a subspace, then


### PR DESCRIPTION
I think that we should attempt to compile the documentation as part of the CI tests, which I have now mentioned in #151.