### PR TITLE
Fix documentation for and rename Perm.VeryFewPoints

### DIFF
--- a/doc/afterrecog.xml
+++ b/doc/afterrecog.xml
@@ -27,7 +27,7 @@ Group([ (1,2,3,4,5,6,7,8,9,10,11,12), (1,2), (13,14,15,16,17), (13,14) ])
 gap> ri := RecogniseGroup(g);
 #I  Finished rank 90 method "NonTransitive": success.
 #I  Going to the factor (depth=0, try=1).
-#I  Finished rank 95 method "VeryFewPoints": success.
+#I  Finished rank 95 method "MovesOnlySmallPoints": success.
 #I  Back from factor (depth=0).
 #I  Calculating preimages of nice generators.
 #I  Creating 20 random generators for kernel.
@@ -36,7 +36,7 @@ gap> ri := RecogniseGroup(g);
 #I  Finished rank 80 method "Giant": success.
 #I  Back from kernel (depth=0).
 <recoginfo NonTransitive
- F:<recoginfo VeryFewPoints Size=120>
+ F:<recoginfo MovesOnlySmallPoints Size=120>
  K:<recoginfo Giant Size=479001600>>]]>
 </Log>
 

--- a/gap/perm.gi
+++ b/gap/perm.gi
@@ -16,7 +16,7 @@
 ##
 #############################################################################
 
-#! @BeginChunk VeryFewPoints
+#! @BeginChunk MovesOnlySmallPoints
 #! If a permutation group moves only small points
 #! (currently, this means that its largest moved point is at most 10),
 #! then this method computes a stabilizer chain for the group via
@@ -28,7 +28,7 @@
 #! If the input group moves a large point (currently, this means a point
 #! larger than 10), then this method returns <K>NeverApplicable</K>.
 #! @EndChunk
-FindHomMethodsPerm.VeryFewPoints := function(ri, G)
+FindHomMethodsPerm.MovesOnlySmallPoints := function(ri, G)
   if LargestMovedPoint(G) <= 10 then
       return FindHomMethodsPerm.StabChain(ri, G);
   fi;
@@ -422,8 +422,8 @@ AddMethod(FindHomDbPerm, FindHomMethodsGeneric.FewGensAbelian,
 AddMethod(FindHomDbPerm, FindHomMethodsPerm.Pcgs,
           97, "Pcgs",
           "use a Pcgs to calculate a stabilizer chain" );
-AddMethod(FindHomDbPerm, FindHomMethodsPerm.VeryFewPoints,
-          95, "VeryFewPoints",
+AddMethod(FindHomDbPerm, FindHomMethodsPerm.MovesOnlySmallPoints,
+          95, "MovesOnlySmallPoints",
           "calculate a stabilizer chain if only small points are moved");
 AddMethod(FindHomDbPerm, FindHomMethodsPerm.NonTransitive,
           90, "NonTransitive",

--- a/gap/perm.gi
+++ b/gap/perm.gi
@@ -17,18 +17,22 @@
 #############################################################################
 
 #! @BeginChunk VeryFewPoints
-#! If a permutation group acts only on a few points (the current limit is at
-#! most 10 points) then a stabiliser chain is computed by the randomized &GAP;
-#! library function for that purpose. If the method is successful then the
-#! calling node becomes a leaf node in the recursive scheme. If the input group
-#! acts on more than 10 points then the method returns <K>NeverApplicable</K>.
+#! If a permutation group moves only small points
+#! (currently, this means that its largest moved point is at most 10),
+#! then this method computes a stabilizer chain for the group via
+#! <Ref Subsect="StabChain" Style="Text"/>.
+#! This is because the most convenient way of solving constructive membership
+#! in such a group is via a stabilizer chain.
+#! In this case, the calling node becomes a leaf node of the composition tree.
+#!
+#! If the input group moves a large point (currently, this means a point
+#! larger than 10), then this method returns <K>NeverApplicable</K>.
 #! @EndChunk
 FindHomMethodsPerm.VeryFewPoints := function(ri, G)
   if LargestMovedPoint(G) <= 10 then
       return FindHomMethodsPerm.StabChain(ri, G);
-  else
-      return NeverApplicable;
   fi;
+  return NeverApplicable;
 end;
 
 #! @BeginChunk NonTransitive
@@ -417,10 +421,10 @@ AddMethod(FindHomDbPerm, FindHomMethodsGeneric.FewGensAbelian,
          "if very few generators, check IsAbelian and if yes, do KnownNilpotent");
 AddMethod(FindHomDbPerm, FindHomMethodsPerm.Pcgs,
           97, "Pcgs",
-          "use a Pcgs to calculate a StabChain" );
+          "use a Pcgs to calculate a stabilizer chain" );
 AddMethod(FindHomDbPerm, FindHomMethodsPerm.VeryFewPoints,
           95, "VeryFewPoints",
-          "calculate a stabchain if we act on very few points");
+          "calculate a stabilizer chain if only small points are moved");
 AddMethod(FindHomDbPerm, FindHomMethodsPerm.NonTransitive,
           90, "NonTransitive",
           "try to find non-transitivity and restrict to orbit");

--- a/tst/working/slow/basic.tst
+++ b/tst/working/slow/basic.tst
@@ -1,7 +1,7 @@
 #
 gap> START_TEST("basic.tst");
 
-# Test for VeryFewPoints:
+# Test for MovesOnlySmallPoints:
 gap> g := SymmetricGroup(5);;
 gap> ri := RECOG.TestGroup(g,false,120);;
 
@@ -17,15 +17,15 @@ gap> ri := RECOG.TestGroup(g,false,Factorial(5)*Factorial(6));;
 gap> g := WreathProduct(SymmetricGroup(5),SymmetricGroup(12));;
 gap> ri := RECOG.TestGroup(g,false,Factorial(5)^12*Factorial(12));;
 
-# Test for VeryFewPoints:
+# Test for MovesOnlySmallPoints:
 gap> g := WreathProduct(SymmetricGroup(2),SymmetricGroup(100));;
 gap> ri := RECOG.TestGroup(g,false,Factorial(2)^100*Factorial(100));;
 
-# Test for VeryFewPoints:
+# Test for MovesOnlySmallPoints:
 gap> g := WreathProduct(SymmetricGroup(5),SymmetricGroup(32));;
 gap> ri := RECOG.TestGroup(g,false,Factorial(5)^32*Factorial(32));;
 
-# Test for VeryFewPoints:
+# Test for MovesOnlySmallPoints:
 gap> g := WreathProduct(AlternatingGroup(5),SymmetricGroup(32));;
 gap> ri := RECOG.TestGroup(g,false,(Factorial(5)/2)^32 * Factorial(32));;
 


### PR DESCRIPTION
This resolves #141.

If people object to the renaming, then I don't mind dropping that commit.