### PR TITLE
Tweak and reformat code in several files

### DIFF
--- a/contrib/frank/guessq.g
+++ b/contrib/frank/guessq.g
@@ -611,7 +611,7 @@ end;
 ro := RandomProjectiveOrders;
 
 testPossibleCrossCharTypes := function(typ, rk, q, dim)
-  local g, i, mm, nonew, o, mm1, ords;
+  local g, i, mm, nonew, o, mm1, ords, possibleChars;
   if typ in ["A","~A"] then
     g := SL(rk+1, q);
   elif typ in ["2A","2~A"] then
@@ -643,15 +643,15 @@ testPossibleCrossCharTypes := function(typ, rk, q, dim)
       nonew := 0;
     fi;
     mm := mm1;
+    # the possible characteristics (i.e. primes)
+    possibleChars := Set(mm, a -> SmallestRootInt(a[1])); 
     if nonew = 30 then
-      return [i-29, Set(List(mm, a-> SmallestRootInt(a[1]))),
-              ords{[1..i-29]}, mm];
-    fi;
-    if Length(Set(List(mm, a-> SmallestRootInt(a[1])))) = 1 then
-      return [i, Set(List(mm, a-> SmallestRootInt(a[1]))), ords, mm];
+      return [i-29, possibleChars, ords{[1..i-29]}, mm];
+    elif Length(x) = 1 then
+      return [i, possibleChars, ords, mm];
     fi;
   od;
-  return [i, Set(List(mm, a-> SmallestRootInt(a[1]))), ords, mm];
+  return [i, possibleChars, ords, mm];
 end;
 
 MakeGroups := function(dat)

--- a/gap/almostsimple.gi
+++ b/gap/almostsimple.gi
@@ -779,7 +779,9 @@ FindHomMethodsProjective.ThreeLargeElOrders := function(ri,G)
           fi;
           res := LookupHintForSimple(ri,G,namecat);
       fi;
-      if res = true then return Success; fi;
+      if res = true then
+          return Success;
+      fi;
   od;
   Info(InfoRecog,2,"Did not succeed with hints, giving up...");
   return fail; # FIXME: fail = TemporaryFailure here really correct?
@@ -919,7 +921,9 @@ end;
 RECOG.HomFDPM := function(data,x)
   local r;
   r := RECOG.FindPermutation(data.cob*x*data.cobi,data.fdpm);
-  if r = fail then return fail; fi;
+  if r = fail then
+      return fail;
+  fi;
   return r[2];
 end;
 
@@ -1279,7 +1283,9 @@ RECOG.RuleOutSmallProjOrder := function(m)
   local l,o,v;
   if IsPerm(m) then
       o := Order(m);
-      if o > 119 then return fail; fi;
+      if o > 119 then
+          return fail;
+      fi;
       return o;
   fi;
   v := ShallowCopy(m[1]);
@@ -1287,15 +1293,21 @@ RECOG.RuleOutSmallProjOrder := function(m)
   ORB_NormalizeVector(v);
   o := Orb([m],v,OnLines,rec( hashlen := 300, report := 0 ));
   Enumerate(o,121);
-  if not(IsClosed(o)) then return fail; fi;
+  if not IsClosed(o) then
+      return fail;
+  fi;
   l := Length(o);
   Randomize(v);
   ORB_NormalizeVector(v);
   o := Orb([m],v,OnLines,rec( hashlen := 300, report := 0 ));
   Enumerate(o,121);
-  if not(IsClosed(o)) then return fail; fi;
+  if not IsClosed(o) then
+      return fail;
+  fi;
   l := Lcm(l,Length(o));
-  if l > 119 then return fail; fi;
+  if l > 119 then
+      return fail;
+  fi;
   return l;
 end;
 

--- a/gap/almostsimple.gi
+++ b/gap/almostsimple.gi
@@ -21,12 +21,10 @@
 RECOG.ParseNumber := function( number, d, default )
   if IsInt(number) then
       return number;
-  fi;
-  if IsString(number) then
-      if number = "logd" then return LogInt(d,2); fi;
-      if number[Length(number)] = 'd' then
-          return d * Int(number{[1..Length(number)-1]});
-      fi;
+  elif number = "logd" then
+      return LogInt(d, 2);
+  elif IsString(number) and EndsWith(number, "d") then
+      return d * Int(number{[1..Length(number)-1]});
   fi;
   return default;
 end;
@@ -1341,8 +1339,7 @@ FindHomMethodsProjective.SporadicsByOrders := function(ri,G)
       if o = fail then
           Info(InfoRecog,2,"Ruled out all sporadic groups.");
           return NeverApplicable;
-      fi;
-      if i <= Length(gens) then
+      elif i <= Length(gens) then
           r.order := ri!.order(r.el);
       else
           GetElmOrd(ri,r);
@@ -1400,8 +1397,7 @@ FindHomMethodsProjective.SporadicsByOrders := function(ri,G)
       if l = [] then
           Info(InfoRecog,2,"Ruled out all sporadic groups.");
           return NeverApplicable;
-      fi;
-      if Length(l) = 1 then
+      elif Length(l) = 1 then
         count := count + 1;
         if count >= 9 then
           Info(InfoRecog,2,"I guess that this is the sporadic simple group ",

--- a/gap/almostsimple.gi
+++ b/gap/almostsimple.gi
@@ -327,7 +327,7 @@ RECOG.AlmostSimpleHints := rec();
 # Currently just sporadic simple groups are contained.
 InstallGlobalFunction( InstallAlmostSimpleHint,
   function( name, type, re )
-    if not(IsBound(RECOG.AlmostSimpleHints.(name))) then
+    if not IsBound(RECOG.AlmostSimpleHints.(name)) then
         RECOG.AlmostSimpleHints.(name) := [];
     fi;
     re.type := type;
@@ -432,7 +432,7 @@ end;
 
 
 # This is for the released AtlasRep package:
-if not(IsBound(AGR_TablesOfContents)) then
+if not IsBound(AGR_TablesOfContents) then
     AGR_TablesOfContents := fail;
     AGR_InfoForName := fail;
 fi;
@@ -554,7 +554,7 @@ RECOG.findchar:=function(ri,G,randelfunc)
     vs:=VectorSpace(GF(p),mat);
     repeat
         vec:=Random(vs);
-    until not(IsZero(vec));
+    until not IsZero(vec);
 
     if RECOG.shortorbit(vec,Product(GeneratorsOfGroup(G)), 3*d) = 3*d then
         return p;
@@ -719,7 +719,7 @@ end;
 RECOG.RandElFuncSimpleSocle := function(ri)
   local el,ord;
   ri!.simplesoclerandp := ri!.simplesoclerandp + 1;
-  if not(IsBound(ri!.simplesoclerand[ri!.simplesoclerandp])) then
+  if not IsBound(ri!.simplesoclerand[ri!.simplesoclerandp]) then
       el := Next(ri!.simplesoclepr);
       ri!.simplesoclerand[ri!.simplesoclerandp] := el;
       ord := ProjectiveOrder(el)[1];
@@ -960,7 +960,7 @@ FindHomMethodsProjective.AltSymBBByDegree := function(ri,G)
           # Now make a homomorphism object:
           newgens := List(GeneratorsOfGroup(G),
                           x->RECOG.HomFDPM(r,x));
-          if not(fail in newgens) then
+          if not fail in newgens then
               GG := GroupWithGenerators(newgens);
               hom := GroupHomByFuncWithData(G,GG,RECOG.HomFDPM,r);
 
@@ -1368,7 +1368,7 @@ FindHomMethodsProjective.SporadicsByOrders := function(ri,G)
           raus := false;
           # check whether orders appear in killers
           for k in [1..Length(RECOG.SporadicsElementOrders[jj])] do
-              if not(RECOG.SporadicsElementOrders[jj][k] in ordersseen) and
+              if not RECOG.SporadicsElementOrders[jj][k] in ordersseen and
                  (1-RECOG.SporadicsProbabilities[jj][k])^i < limit then
                   Info(InfoRecog,3,"Have thrown out ",RECOG.SporadicsNames[jj],
                        " (did not see order ",
@@ -1377,7 +1377,7 @@ FindHomMethodsProjective.SporadicsByOrders := function(ri,G)
                   break;
               fi;
           od;
-          if not(raus) and IsBound(RECOG.SporadicsKillers[jj]) then
+          if not raus and IsBound(RECOG.SporadicsKillers[jj]) then
             for killers in RECOG.SporadicsKillers[jj] do
               if Intersection(ordersseen,
                               RECOG.SporadicsElementOrders[jj]{killers})=[]

--- a/gap/c3c5.gi
+++ b/gap/c3c5.gi
@@ -155,8 +155,8 @@ FindHomMethodsProjective.NotAbsolutelyIrred := function(ri,G)
       return NeverApplicable;
   fi;
 
-  Info(InfoRecog,2,"Rewriting generators over larger field with smaller",
-       " degree, factor=",MTX.DegreeSplittingField(m));
+  Info(InfoRecog,2, "Rewriting generators over larger field with smaller ",
+                    "degree, factor=", MTX.DegreeSplittingField(m));
 
   r := RECOG.WriteOverBiggerFieldWithSmallerDegreeFinder(m);
   H := GroupWithGenerators(r.newgens);
@@ -408,8 +408,9 @@ FindHomMethodsProjective.Subfield :=  function(ri,G)
     pf := PrimeField(f);
     b := RECOG.BaseChangeForSmallestPossibleField(G,ri!.meataxemodule,f);
     if b <> fail then
-        Info(InfoRecog,2,"Conjugating group from GL(",dim,",",f,
-             ") into GL(",dim,",",b.field,").");
+        Info(InfoRecog, 2, StringFormatted(
+             "Conjugating group from GL({},{}) into GL({},{}).",
+             dim, f, dim, b.field));
         # Do base change isomorphism:
         H := GroupWithGenerators(b.newgens);
         hom := GroupHomByFuncWithData(G,H,RECOG.HomDoBaseAndFieldChange,b);
@@ -527,7 +528,7 @@ FindHomMethodsProjective.C3C5 := function(ri,G)
   pr2 := ProductReplacer(GeneratorsOfGroup(G),rec(noaccu := true));
   pr := ProductReplacer(coms,rec(normalin := pr2));
   nr := Minimum(Maximum(5,QuoInt(dim*Log2Int(Size(f)),20)),40);
-  Info( InfoRecog, 3, "C3C5: computing ",nr," generators for N...");
+  Info(InfoRecog, 3, "C3C5: computing ", nr," generators for N...");
   Hgens := ShallowCopy(coms);
   for i in [1..nr] do
       Add(Hgens,Next(pr));
@@ -553,14 +554,16 @@ FindHomMethodsProjective.C3C5 := function(ri,G)
       if not IsPrimeField(f) then
           b := RECOG.BaseChangeForSmallestPossibleField(H,m,f);
           if b <> fail then   # Yes! N is realisable!
-                Info(InfoRecog,2,"Can conjugate H subgroup from GL(",dim,
-                     ",",f,") into GL(",dim,",",b.field,").");
+                Info(InfoRecog, 2, StringFormatted(
+                     "Can conjugate H subgroup from GL({},{}) into GL({},{}).",
+                     dim, f, dim, b.field));
                 # Now do base change for generators of G:
               newgens := List(gens,x->b.t*x*b.ti);
               r := RECOG.ScalarsToMultiplyIntoSmallerField(newgens,f);
               if r <> fail then   # Yes again! This works!
-                  Info(InfoRecog,2,"Conjugating group from GL(",dim,",",f,
-                       ") into GL(",dim,",",r.field,").");
+                  Info(InfoRecog, 2, StringFormatted(
+                       "Conjugating group from GL({},{}) into GL({},{}).",
+                       dim, f, dim, r.field));
 
                   # Set up an isomorphism:
                   H := GroupWithGenerators(newgens);
@@ -575,14 +578,14 @@ FindHomMethodsProjective.C3C5 := function(ri,G)
           fi;
       fi;
       # We now know that G is not C5!
-      Info(InfoRecog,2,"G is not C5 (subfield).");
+      Info(InfoRecog, 2, "G is not C5 (subfield).");
 
       # Check whether m is not absolutely irreducible, then G is C3,
       # otherwise not!
       if MTX.IsAbsolutelyIrreducible(m) then
           # We fail, G is neither C3 nor C5, and we do not find a way
           # for any reduction using H:
-          Info(InfoRecog,2,"G is not C3 (semilinear).");
+          Info(InfoRecog, 2, "G is not C3 (semilinear).");
           return NeverApplicable;
       fi;
 
@@ -607,14 +610,14 @@ FindHomMethodsProjective.C3C5 := function(ri,G)
           x := cgen^g;
           pos := Position(c,x);
           if pos = fail then   # something is wrong!
-              Info( InfoRecog, 1, "Sudden failure, G should be C3 but isn't! ",
-                    "C3C5 gives up for the moment." );
+              Info(InfoRecog, 1, "Sudden failure, G should be C3 but isn't! ",
+                                 "C3C5 gives up for the moment." );
               return TemporaryFailure;
           fi;
           Add(gensim,cyc^cc[pos]);
       od;
-      Info( InfoRecog, 2, "G is C3, found action as field auts of size ",
-            deg,".");
+      Info(InfoRecog, 2, StringFormatted(
+           "G is C3, found action as field auts of size {}.", deg));
       HH := GroupWithGenerators(gensim);
       hom := GroupHomByFuncWithData(G,HH,RECOG.HomActionFieldAuto,
                   rec( c := c,cc := cc,cgen := cgen, cyc := cyc ) );
@@ -642,7 +645,7 @@ FindHomMethodsProjective.C3C5 := function(ri,G)
               ErrorNoReturn("This should never have happened (2), tell Max.");
               # This should have been caught by the scalar test above.
           fi;
-          Info(InfoRecog,2,"Restriction to H is homogeneous.");
+          Info(InfoRecog, 2, "Restriction to H is homogeneous.");
           if not MTX.IsAbsolutelyIrreducible(collf[1][1]) then
               ErrorNoReturn("Is this really possible??? G acts absolutely irred!");
           fi;
@@ -658,8 +661,8 @@ FindHomMethodsProjective.C3C5 := function(ri,G)
           conjgensG := List(gens,x->r.t * x * r.ti);
           kro := List(conjgensG,g->RECOG.IsKroneckerProduct(g,r.blocksize));
           if not ForAll(kro, k -> k[1]) then
-              Info(InfoRecog,1,"VERY, VERY, STRANGE!");
-              Info(InfoRecog,1,"False alarm, was not a tensor decomposition.");
+              Info(InfoRecog, 1, "VERY, VERY, STRANGE!");
+              Info(InfoRecog, 1, "False alarm, was not a tensor decomposition.");
               ErrorNoReturn("This should never have happened (3), tell Max.");
           fi;
 
@@ -678,8 +681,9 @@ FindHomMethodsProjective.C3C5 := function(ri,G)
           findgensNmeth(ri).method := FindKernelDoNothing;
           return Success;
       fi;
-      Info(InfoRecog,2,"Using action on the set of homogeneous components",
-           " (",Length(collf)," elements)...");
+      Info(InfoRecog, 2, StringFormatted(
+           "Using action on the set of homogeneous components ({} elements)...",
+           Length(collf)));
       # Now find a homogeneous component to act on it:
       homs := MTX.Homomorphisms(collf[1][1],m);
       homsimg := BasisVectors(Basis(VectorSpace(f,Concatenation(homs))));

--- a/gap/c3c5.gi
+++ b/gap/c3c5.gi
@@ -201,13 +201,12 @@ end;
 FindHomMethodsProjective.BiggerScalarsOnly := function(ri,G)
   # We come here only hinted, we project to a little square block in the
   # upper left corner and know that there is no kernel:
-  local H,data,hom,newgens;
+  local H, data, hom;
   data := rec(poss := [1..ri!.degsplittingfield],
               bas  := ri!.biggerscalarsbas,
               basi := ri!.biggerscalarsbasi);
-  newgens := List(GeneratorsOfGroup(G),x->RECOG.HomBCToDiagonalBlock(data,x));
-  H := Group(newgens);
-  hom := GroupHomByFuncWithData(G,H,RECOG.HomBCToDiagonalBlock,data);
+  H := List(GeneratorsOfGroup(G), x-> RECOG.HomBCToDiagonalBlock(data, x));
+  hom := GroupHomByFuncWithData(G, Group(H), RECOG.HomBCToDiagonalBlock, data);
   SetHomom(ri,hom);
 
   Add(forfactor(ri).hints,
@@ -296,11 +295,11 @@ RECOG.BaseChangeForSmallestPossibleField := function(grp,mtx,k)
   element := false ;
   a := Zero(GeneratorsOfGroup(grp)[1]);
   dim := Length(a);
-  while ( element = false ) do
-    a := a + Random ( f ) * PseudoRandom ( grp ) ;
+  while element = false do
+    a := a + Random(f) * PseudoRandom(grp);
 
     # Check char. polynomial of a to make sure it lies in smallField [ x ]
-    charPoly := CharacteristicPolynomial ( a ) ;
+    charPoly := CharacteristicPolynomial(a);
     field := Field(CoefficientsOfLaurentPolynomial(charPoly)[1]);
     if not IsSubset(f, field) then
         f := ClosureField(f,field);
@@ -336,7 +335,7 @@ RECOG.BaseChangeForSmallestPossibleField := function(grp,mtx,k)
   while Length(b) < dim do
       for g in GeneratorsOfGroup(grp) do
           w := b[i] * g;
-          if RECOG.CleanRow( seb, ShallowCopy(w), true, fail ) = false then
+          if not RECOG.CleanRow(seb, ShallowCopy(w), true, fail) then
               Add(b,w);
           fi;
       od;
@@ -647,7 +646,7 @@ FindHomMethodsProjective.C3C5 := function(ri,G)
           fi;
           Info(InfoRecog, 2, "Restriction to H is homogeneous.");
           if not MTX.IsAbsolutelyIrreducible(collf[1][1]) then
-              ErrorNoReturn("Is this really possible??? G acts absolutely irred!");
+              ErrorNoReturn("Is this really possible? G acts absolutely irred!");
           fi;
           homs := MTX.Homomorphisms(collf[1][1],m);
           basis := Concatenation(homs);

--- a/gap/c3c5.gi
+++ b/gap/c3c5.gi
@@ -397,12 +397,12 @@ FindHomMethodsProjective.Subfield :=  function(ri,G)
     RECOG.SetPseudoRandomStamp(G,"Subfield");
     f := ri!.field;
     if IsPrimeField(f) then
-        return false;     # nothing to do
+        return NeverApplicable;     # nothing to do
     elif not IsBound(ri!.meataxemodule) then
         ri!.meataxemodule := GModuleByMats(GeneratorsOfGroup(G),f);
     fi;
     if not MTX.IsIrreducible(ri!.meataxemodule) then
-        return false;     # not our case
+        return NeverApplicable;     # not our case
     fi;
     dim := ri!.dimension;
     pf := PrimeField(f);
@@ -421,7 +421,8 @@ FindHomMethodsProjective.Subfield :=  function(ri,G)
         return Success;
     fi;
 
-    return false;   # nothing more to do for us, C3C5 takes care of the rest!
+    # nothing more to do for us, C3C5 takes care of the rest!
+    return NeverApplicable;
   end;
 
 RECOG.HomActionFieldAuto := function(data,el)

--- a/gap/c3c5.gi
+++ b/gap/c3c5.gi
@@ -51,7 +51,7 @@ RECOG.WriteOverBiggerFieldWithSmallerDegreeFinder := function(m)
   # m a MeatAxe-module
   local F,bas,d,dim,e,fac,facs,gens,i,inforec,j,k,mp,mu,new,newgens,pr,q,v;
 
-  if not(MTX.IsIrreducible(m)) then
+  if not MTX.IsIrreducible(m) then
       ErrorNoReturn("cannot work for reducible modules");
   fi;
   if MTX.IsAbsolutelyIrreducible(m) = true then
@@ -83,8 +83,8 @@ RECOG.WriteOverBiggerFieldWithSmallerDegreeFinder := function(m)
   while Length(bas) < dim do
       for j in [1..Length(gens)] do
           new := bas[i] * gens[j];
-          if not(RECOG.CleanRow(mu,ShallowCopy(new),true,fail)) then
-          #if not(IsContainedInSpan(mu,new)) then
+          if not RECOG.CleanRow(mu, ShallowCopy(new), true, fail) then
+          #if not IsContainedInSpan(mu, new) then
               Add(bas,new);
               #CloseMutableBasis(mu,new);
               for k in [1..d-1] do
@@ -147,7 +147,7 @@ FindHomMethodsProjective.NotAbsolutelyIrred := function(ri,G)
 
   # This usually comes after "ReducibleIso", which provides the following,
   # however, just to be sure:
-  if not(IsBound(ri!.meataxemodule)) then
+  if not IsBound(ri!.meataxemodule) then
       ri!.meataxemodule := GModuleByMats(GeneratorsOfGroup(G),f);
   fi;
 
@@ -258,7 +258,7 @@ RECOG.ScalarsToMultiplyIntoSmallerField := function(l,k)
       if r = fail then
           return fail;
       fi;
-      if not(IsSubset(f,r.field)) then
+      if not IsSubset(f, r.field) then
           f := ClosureField(f,r.field);
           if f = k then
               return fail;
@@ -302,7 +302,7 @@ RECOG.BaseChangeForSmallestPossibleField := function(grp,mtx,k)
     # Check char. polynomial of a to make sure it lies in smallField [ x ]
     charPoly := CharacteristicPolynomial ( a ) ;
     field := Field(CoefficientsOfLaurentPolynomial(charPoly)[1]);
-    if not(IsSubset(f,field)) then
+    if not IsSubset(f, field) then
         f := ClosureField(f,field);
         if Size(f) >= Size(k) then
             return fail;
@@ -399,10 +399,10 @@ FindHomMethodsProjective.Subfield :=  function(ri,G)
     if IsPrimeField(f) then
         return false;     # nothing to do
     fi;
-    if not(IsBound(ri!.meataxemodule)) then
+    if not IsBound(ri!.meataxemodule) then
         ri!.meataxemodule := GModuleByMats(GeneratorsOfGroup(G),f);
     fi;
-    if not(MTX.IsIrreducible(ri!.meataxemodule)) then
+    if not MTX.IsIrreducible(ri!.meataxemodule) then
         return false;     # not our case
     fi;
     dim := ri!.dimension;
@@ -459,10 +459,10 @@ FindHomMethodsProjective.C3C5 := function(ri,G)
   RECOG.SetPseudoRandomStamp(G,"C3C5");
 
   f := ri!.field;
-  if not(IsBound(ri!.meataxemodule)) then
+  if not IsBound(ri!.meataxemodule) then
       ri!.meataxemodule := GModuleByMats(GeneratorsOfGroup(G),f);
   fi;
-  if not(MTX.IsIrreducible(ri!.meataxemodule)) then
+  if not MTX.IsIrreducible(ri!.meataxemodule) then
       return NeverApplicable;     # not our case
   fi;
   dim := ri!.dimension;
@@ -550,7 +550,7 @@ FindHomMethodsProjective.C3C5 := function(ri,G)
       # So, we first test for C5 in either case and only if this does not
       # work we settle C3:
 
-      if not(IsPrimeField(f)) then
+      if not IsPrimeField(f) then
           b := RECOG.BaseChangeForSmallestPossibleField(H,m,f);
           if b <> fail then   # Yes! N is realisable!
                 Info(InfoRecog,2,"Can conjugate H subgroup from GL(",dim,
@@ -643,7 +643,7 @@ FindHomMethodsProjective.C3C5 := function(ri,G)
               # This should have been caught by the scalar test above.
           fi;
           Info(InfoRecog,2,"Restriction to H is homogeneous.");
-          if not(MTX.IsAbsolutelyIrreducible(collf[1][1])) then
+          if not MTX.IsAbsolutelyIrreducible(collf[1][1]) then
               ErrorNoReturn("Is this really possible??? G acts absolutely irred!");
           fi;
           homs := MTX.Homomorphisms(collf[1][1],m);
@@ -657,7 +657,7 @@ FindHomMethodsProjective.C3C5 := function(ri,G)
           # Now we believe to have a tensor decomposition:
           conjgensG := List(gens,x->r.t * x * r.ti);
           kro := List(conjgensG,g->RECOG.IsKroneckerProduct(g,r.blocksize));
-          if not(ForAll(kro,k->k[1] = true)) then
+          if not ForAll(kro, k -> k[1]) then
               Info(InfoRecog,1,"VERY, VERY, STRANGE!");
               Info(InfoRecog,1,"False alarm, was not a tensor decomposition.");
               ErrorNoReturn("This should never have happened (3), tell Max.");

--- a/gap/c3c5.gi
+++ b/gap/c3c5.gi
@@ -230,12 +230,16 @@ RECOG.ScalarToMultiplyIntoSmallerField := function(m,k)
   # such that r.mat = r.scalar * m and r.mat has entries in r.field
   # and r.field is a field contained in Field(m).
   local f,mm,pos,s;
-  if IsPrimeField(k) then return fail; fi;
+  if IsPrimeField(k) then
+      return fail;
+  fi;
   pos := PositionNonZero(m[1]);
   s := m[1][pos]^-1;
   mm := s * m;
   f := FieldOfMatrixList([mm]);
-  if k = f then return fail; fi;
+  if k = f then
+      return fail;
+  fi;
   return rec( mat := mm, scalar := s, field := f );
 end;
 
@@ -251,7 +255,9 @@ RECOG.ScalarsToMultiplyIntoSmallerField := function(l,k)
   f := PrimeField(k);
   for i in [1..Length(l)] do
       r := RECOG.ScalarToMultiplyIntoSmallerField(l[i],k);
-      if r = fail then return fail; fi;
+      if r = fail then
+          return fail;
+      fi;
       if not(IsSubset(f,r.field)) then
           f := ClosureField(f,r.field);
           if f = k then
@@ -340,7 +346,9 @@ RECOG.BaseChangeForSmallestPossibleField := function(grp,mtx,k)
   bi := b^-1;
   newgens := List(GeneratorsOfGroup(grp),x->b*x*bi);
   f := FieldOfMatrixList(newgens);
-  if f = k then return fail; fi;
+  if f = k then
+      return fail;
+  fi;
   return rec( newgens := newgens, field := f, t := b, ti := bi );
 end;
 
@@ -421,14 +429,18 @@ RECOG.HomActionFieldAuto := function(data,el)
   local pos,y;
   y := data.cgen ^ el;
   pos := Position(data.c,y);
-  if pos = fail then return fail; fi;
+  if pos = fail then
+      return fail;
+  fi;
   return data.cyc^data.cc[pos];
 end;
 
 RECOG.HomCommutator := function(data,el)
   local y;
   y := Comm(data.x,el);
-  if RECOG.IsScalarMat(y) = false then return fail; fi;
+  if RECOG.IsScalarMat(y) = false then
+      return fail;
+  fi;
   return ExtractSubMatrix(y,[1],[1]);
 end;
 

--- a/gap/c3c5.gi
+++ b/gap/c3c5.gi
@@ -53,8 +53,7 @@ RECOG.WriteOverBiggerFieldWithSmallerDegreeFinder := function(m)
 
   if not MTX.IsIrreducible(m) then
       ErrorNoReturn("cannot work for reducible modules");
-  fi;
-  if MTX.IsAbsolutelyIrreducible(m) = true then
+  elif MTX.IsAbsolutelyIrreducible(m) then
       ErrorNoReturn("cannot work for absolutely irreducible modules");
   fi;
 
@@ -257,8 +256,7 @@ RECOG.ScalarsToMultiplyIntoSmallerField := function(l,k)
       r := RECOG.ScalarToMultiplyIntoSmallerField(l[i],k);
       if r = fail then
           return fail;
-      fi;
-      if not IsSubset(f, r.field) then
+      elif not IsSubset(f, r.field) then
           f := ClosureField(f,r.field);
           if f = k then
               return fail;
@@ -398,8 +396,7 @@ FindHomMethodsProjective.Subfield :=  function(ri,G)
     f := ri!.field;
     if IsPrimeField(f) then
         return false;     # nothing to do
-    fi;
-    if not IsBound(ri!.meataxemodule) then
+    elif not IsBound(ri!.meataxemodule) then
         ri!.meataxemodule := GModuleByMats(GeneratorsOfGroup(G),f);
     fi;
     if not MTX.IsIrreducible(ri!.meataxemodule) then

--- a/gap/c3c5.gi
+++ b/gap/c3c5.gi
@@ -178,8 +178,9 @@ FindHomMethodsProjective.NotAbsolutelyIrred := function(ri,G)
   # Also, doing normal closure will not help!
   findgensNmeth(ri).args := [5,0];
   Add(forkernel(ri).hints,
-      rec( method := FindHomMethodsProjective.BiggerScalarsOnly, rank := 2000,
-           stamp := "BiggerScalarsOnly" ));
+      rec(method := FindHomMethodsProjective.BiggerScalarsOnly,
+          rank   := 2000,
+          stamp  := "BiggerScalarsOnly"));
   forkernel(ri).degsplittingfield := MTX.DegreeSplittingField(m)
                                    / DegreeOverPrimeField(f);
   forkernel(ri).biggerscalarsbas := r.inforec.bas;
@@ -201,17 +202,18 @@ FindHomMethodsProjective.BiggerScalarsOnly := function(ri,G)
   # We come here only hinted, we project to a little square block in the
   # upper left corner and know that there is no kernel:
   local H,data,hom,newgens;
-  data := rec( poss := [1..ri!.degsplittingfield],
-               bas := ri!.biggerscalarsbas,
-               basi := ri!.biggerscalarsbasi );
+  data := rec(poss := [1..ri!.degsplittingfield],
+              bas  := ri!.biggerscalarsbas,
+              basi := ri!.biggerscalarsbasi);
   newgens := List(GeneratorsOfGroup(G),x->RECOG.HomBCToDiagonalBlock(data,x));
   H := Group(newgens);
   hom := GroupHomByFuncWithData(G,H,RECOG.HomBCToDiagonalBlock,data);
   SetHomom(ri,hom);
 
   Add(forfactor(ri).hints,
-      rec( method := FindHomMethodsProjective.StabilizerChainProj, rank := 4000,
-           stamp := "StabilizerChainProj" ));
+      rec(method := FindHomMethodsProjective.StabilizerChainProj,
+          rank   := 4000,
+          stamp  := "StabilizerChainProj"));
 
   findgensNmeth(ri).method := FindKernelDoNothing;
 
@@ -265,7 +267,7 @@ RECOG.ScalarsToMultiplyIntoSmallerField := function(l,k)
       scalars[i] := r.scalar;
       newgens[i] := r.mat;
   od;
-  return rec(scalars := scalars, newgens := newgens, field := f );
+  return rec(scalars := scalars, newgens := newgens, field := f);
 end;
 
 RECOG.BaseChangeForSmallestPossibleField := function(grp,mtx,k)
@@ -668,8 +670,9 @@ FindHomMethodsProjective.C3C5 := function(ri,G)
           forfactor(ri).blocksize := r.blocksize;
           forfactor(ri).generatorskronecker := kro;
           Add( forfactor(ri).hints,
-               rec( method := FindHomMethodsProjective.KroneckerProduct,
-                    rank := 4000, stamp := "KroneckerProduct" ) );
+               rec(method := FindHomMethodsProjective.KroneckerProduct,
+                   rank   := 4000,
+                   stamp  := "KroneckerProduct"));
           # This is an isomorphism:
           findgensNmeth(ri).method := FindKernelDoNothing;
           return Success;

--- a/gap/c6.gi
+++ b/gap/c6.gi
@@ -410,7 +410,7 @@ end;
 # decompose a vector space into a sum of common eigenspaces
 # rad is generator list for an abelian matrix group
 RECOG.commondiagonal:=function(q,rad)
-    local xxx, int, es, int2, vs, nicebasis, i, j, k;
+    local int, es, int2, vs, nicebasis, i, j, k;
 
     Info(InfoRecog,3,"enter diagonalization");
 

--- a/gap/classical.gi
+++ b/gap/classical.gi
@@ -1030,12 +1030,8 @@ RECOG.IsSpContained := function( recognise, grp )
     isSpForm := f -> IsSesquilinearForm(f) and IsSymplecticForm(f);
 
     # if the dimension is not even, the group cannot be symplectic
-    if recognise.d mod 2 <> 0 then
+    if recognise.d mod 2 <> 0 or recognise.isSpContained = false then
         recognise.isSpContained := false;
-        return false;
-    fi;
-
-    if recognise.isSpContained = false then
         return false;
     fi;
 

--- a/gap/classical.gi
+++ b/gap/classical.gi
@@ -44,7 +44,9 @@ HasLBGgt5 := function( m, p, a, e )
 
     local pm, i,  ppds;
 
-    if m <= 5 then return false; fi;
+    if m <= 5 then
+        return false;
+    fi;
 
     # Find the basic ppds of p^(ae)-1
     pm := PrimitivePrimeDivisors(a*e, p);
@@ -211,9 +213,11 @@ RECOG.IsGeneric := function (recognise, grp)
         return false;
     fi;
 
-    if Length(recognise.E) < 2 then return fail; fi;
-    if Length(recognise.LE) < 1 then return fail; fi;
-    if Length(recognise.BE) < 1 then return fail; fi;
+    if Length(recognise.E) < 2 or
+       Length(recognise.LE) = 0 or
+       Length(recognise.BE) = 0 then
+        return fail;
+    fi;
 
     recognise.isGeneric := true;
 
@@ -587,7 +591,9 @@ IsPrimitivePrimeDivisor := function( b, a, p )
 
     if (b^a-1) mod p <> 0 then return false; fi;
     for i in [ 1 .. a-1 ] do
-        if (b^i-1) mod p = 0 then return false; fi;
+        if b^i-1 mod p = 0 then
+            return false;
+        fi;
     od;
 
     return true;
@@ -1983,7 +1989,9 @@ RECOG.NonGenericOrthogonalCircle := function( recognise, grp )
         return fail;
     fi;
 
-    if d = 3 then recognise.needLB := true; fi;
+    if d = 3 then
+        recognise.needLB := true;
+    fi;
 
 
     if d = 7 and q = 3 then

--- a/gap/classical.gi
+++ b/gap/classical.gi
@@ -357,7 +357,7 @@ RECOG.IsNotAlternating := function( recognise, grp )
     fi;
 
     if q = 2 then
-       if Size(grp) <> 3*4*5*6*7 then
+       if Size(grp) <> 2520 then  # 2520 = 3*4*5*6*7 = |A7|
            Info( InfoClassical, 2, "G is not an alternating group" );
            recognise.isNotAlternating := true;
            return false;
@@ -826,7 +826,7 @@ RECOG.IsReducible := function( recognise, grp )
     local deg, dims, g;
 
     # compute the degrees of the irreducible factors
-    deg := List(Factors(recognise.cpol), i-> Degree(i));
+    deg := List(Factors(recognise.cpol), Degree);
 
     # compute all possible dimensions
     dims := [0];
@@ -2098,10 +2098,10 @@ AddMethod( ClassicalMethDb, RECOG.TestRandomElement, 100, "TestRandomElement",
            "makes new random element and stores it and its char poly" );
 
 AddMethod( ClassicalMethDb, RECOG.IsGenericParameters,90,"IsGenericParameters",
-           "tests whether grp has  generic parameters" );
+           "tests whether group has generic parameters" );
 
 AddMethod( ClassicalMethDb, RECOG.IsGeneric, 89, "IsGeneric",
-           "tests whether grp is generic" );
+           "tests whether group is generic" );
 
 AddMethod( ClassicalMethDb, RECOG.IsReducible, 80, "IsReducible",
            "tests whether current random element rules out reducible" );
@@ -2112,11 +2112,11 @@ AddMethod( ClassicalMethDb, RECOG.RuledOutExtField, 81,
 
 AddMethod( ClassicalMethDb, RECOG.IsNotMathieu, 82,
            "IsNotMathieu",
-           "tests whether Mathieu Groups are ruled out" );
+           "tests whether Mathieu groups are ruled out" );
 
 AddMethod( ClassicalMethDb, RECOG.IsNotAlternating, 83,
            "IsNotAlternating",
-           "tests whether Alternating Groups are ruled out" );
+           "tests whether alternating groups are ruled out" );
 
 AddMethod( ClassicalMethDb, RECOG.IsNotPSL, 84,
            "IsNotPSL",

--- a/gap/classical.gi
+++ b/gap/classical.gi
@@ -1027,11 +1027,7 @@ RECOG.IsSpContained := function( recognise, grp )
 
     local isSpForm;
 
-    isSpForm := function(f)
-        if not IsSesquilinearForm(f) then return false; fi;
-        if IsSymplecticForm(f) then return true; fi;
-        return false;
-    end;
+    isSpForm := f -> IsSesquilinearForm(f) and IsSymplecticForm(f);
 
     # if the dimension is not even, the group cannot be symplectic
     if recognise.d mod 2 <> 0 then
@@ -1092,12 +1088,7 @@ RECOG.IsSUContained := function( recognise, grp )
 
     local f, isHermForm, q0;
 
-    isHermForm := function(f)
-        if not IsSesquilinearForm(f) then return false; fi;
-        if IsHermitianForm(f) then return true; fi;
-        return false;
-    end;
-
+    isHermForm := f -> IsSesquilinearForm(f) and IsHermitianForm(f);
 
     f := recognise.field;
 
@@ -1160,23 +1151,9 @@ RECOG.IsSOContained := function( recognise, grp )
 
     local f, isParForm, isEllForm, isHypForm;
 
-    isParForm := function(f)
-        if not IsSesquilinearForm(f) then return false; fi;
-        if IsParabolicForm(f) then return true; fi;
-        return false;
-    end;
-
-    isEllForm := function(f)
-        if not IsSesquilinearForm(f) then return false; fi;
-        if IsEllipticForm(f) then return true; fi;
-        return false;
-    end;
-
-    isHypForm := function(f)
-        if not IsSesquilinearForm(f) then return false; fi;
-        if IsHyperbolicForm(f) then return true; fi;
-        return false;
-    end;
+    isParForm := f -> IsSesquilinearForm(f) and IsParabolicForm(f);
+    isEllForm := f -> IsSesquilinearForm(f) and IsEllipticForm(f);
+    isHypForm := f -> IsSesquilinearForm(f) and IsHyperbolicForm(f);
 
     if recognise.isSOContained = false then
         return false;
@@ -1343,12 +1320,7 @@ RECOG.NonGenericSymplectic := function(recognise, grp)
 
     local d, q, CheckFlag, isSpForm;
 
-    isSpForm := function(f)
-        if not IsSesquilinearForm(f) then return false; fi;
-        if IsSymplecticForm(f) then return true; fi;
-        return false;
-    end;
-
+    isSpForm := f -> IsSesquilinearForm(f) and IsSymplecticForm(f);
 
     CheckFlag := function( )
         if recognise.isReducible = "unknown" then
@@ -1457,11 +1429,7 @@ RECOG.NonGenericUnitary := function(recognise, grp)
 
     local d, q,  g, f1, f2, o, CheckFlag, isHermForm, str;
 
-    isHermForm := function(f)
-        if not IsSesquilinearForm(f) then return false; fi;
-        if IsHermitianForm(f) then return true; fi;
-        return false;
-    end;
+    isHermForm := f -> IsSesquilinearForm(f) and IsHermitianForm(f);
 
     CheckFlag := function( )
         if recognise.isReducible = "unknown" then
@@ -1657,11 +1625,7 @@ RECOG.NonGenericOrthogonalPlus := function(recognise,grp)
 
     local d, q, gp1, gp2, CheckFlag, pgrp, orbs, isHypForm;
 
-    isHypForm := function(f)
-        if not IsSesquilinearForm(f) then return false; fi;
-        if IsHyperbolicForm(f) then return true; fi;
-        return false;
-    end;
+    isHypForm := f -> IsSesquilinearForm(f) and IsHyperbolicForm(f);
 
     CheckFlag := function( )
         if recognise.isReducible = "unknown" then
@@ -1881,11 +1845,7 @@ RECOG.NonGenericOrthogonalMinus := function(recognise, grp)
     local d, q,  orbs, pgrp, h,  g, ppd,  CheckFlag, isEllForm;
 
 
-    isEllForm := function(f)
-        if not IsSesquilinearForm(f) then return false; fi;
-        if IsEllipticForm(f) then return true; fi;
-        return false;
-    end;
+    isEllForm := f -> IsSesquilinearForm(f) and IsEllipticForm(f);
 
     CheckFlag := function( )
         if recognise.isReducible = "unknown" then
@@ -1985,11 +1945,7 @@ RECOG.NonGenericOrthogonalCircle := function( recognise, grp )
 
     local d, q, g, s, CheckFlag, isParForm;
 
-    isParForm := function(f)
-        if not IsSesquilinearForm(f) then return false; fi;
-        if IsParabolicForm(f) then return true; fi;
-        return false;
-    end;
+    isParForm := f -> IsSesquilinearForm(f) and IsParabolicForm(f);
 
     if not IsOddInt(recognise.d) then return false; fi;
     if not IsOddInt(recognise.q) then return false; fi;

--- a/gap/classical.gi
+++ b/gap/classical.gi
@@ -800,8 +800,7 @@ RECOG.TestRandomElement := function (recognise, grp)
             if recognise.kf = "unknown" then
                 recognise.needKF := true;
                 return fail;
-            fi;
-            if recognise.kf = false then
+            elif recognise.kf = false then
                 return fail;
             fi;
             kf := recognise.kf;

--- a/gap/d247.gi
+++ b/gap/d247.gi
@@ -81,7 +81,7 @@ RECOG.InvolutionJumper := function(pr,ord,x,tol,withodd)
       if IsEvenInt(o) then
           return c^(o/2);
       fi;
-      if not(withodd) then
+      if not withodd then
           continue;
       fi;
       z := y*c^((o-1)/2);
@@ -106,7 +106,7 @@ RECOG.DirectFactorsFinder := function(gens,facgens,k,eq)
           while i <= 4 do
               Add(fgens,Next(pr),1);
               if ForAny([2..Length(fgens)],
-                        j->not(eq(fgens[1]*fgens[j],fgens[j]*fgens[1]))) then
+                        j -> not eq(fgens[1]*fgens[j], fgens[j]*fgens[1])) then
                   break;
               fi;
               i := i + 1;
@@ -121,7 +121,7 @@ RECOG.DirectFactorsFinder := function(gens,facgens,k,eq)
   fi;
 
   equal := function(a,b)
-    return ForAny(b,y-> not(eq(a*y,y*a)));
+    return ForAny(b, y -> not eq(a*y, y*a));
   end;
 
   # Enumerate orbit:
@@ -132,7 +132,7 @@ RECOG.DirectFactorsFinder := function(gens,facgens,k,eq)
     for j in [1..Length(gens)] do
       z := o[i][1]^gens[j];
       l := 1;
-      while l <= Length(o) and not(equal(z,o[l])) do
+      while l <= Length(o) and not equal(z, o[l]) do
           l := l + 1;
       od;
       pgens[j][i] := l;
@@ -166,14 +166,14 @@ RECOG.DirectFactorsAction := function(data,el)
   o := data.o;
 
   equal := function(a,b)
-    return ForAny(b,y-> not(eq(a*y,y*a)));
+    return ForAny(b, y -> not eq(a*y, y*a));
   end;
 
   res := EmptyPlist(Length(o));
   for i in [1..Length(o)] do
     z := o[i][1]^el;
     j := 1;
-    while j <= Length(o) and not(equal(z,o[j])) do
+    while j <= Length(o) and not equal(z, o[j]) do
         j := j + 1;
     od;
     if j <= Length(o) then
@@ -225,7 +225,7 @@ RECOG.SortOutReducibleNormalSubgroup :=
             return TemporaryFailure;
         fi;
         Info(InfoRecog,2,"D247:Restriction to normal subgroup is homogeneous.");
-        if not(MTX.IsAbsolutelyIrreducible(collf[1][1])) then
+        if not MTX.IsAbsolutelyIrreducible(collf[1][1]) then
             ErrorNoReturn("Is this really possible??? G acts absolutely irred!");
         fi;
         homs := MTX.Homomorphisms(collf[1][1],m);
@@ -240,7 +240,7 @@ RECOG.SortOutReducibleNormalSubgroup :=
         # Now we believe to have a tensor decomposition:
         conjgensG := List(GeneratorsOfGroup(G),x->r.t * x * r.ti);
         kro := List(conjgensG,g->RECOG.IsKroneckerProduct(g,r.blocksize));
-        if not(ForAll(kro,k->k[1] = true)) then
+        if not ForAll(kro, k -> k[1]) then
             Info(InfoRecog,1,"VERY, VERY, STRANGE!");
             Info(InfoRecog,1,"False alarm, was not a tensor decomposition.");
             ErrorNoReturn("This should never have happened (346), tell Max.");
@@ -276,7 +276,7 @@ ConvertToMatrixRep(homcomp,Size(f));
     TriangulizeMat(homcomp);
     o := Orb(G,homcomp,OnSubspacesByCanonicalBasis,rec(storenumbers := true));
     Enumerate(o,QuoInt(ri!.dimension,Length(homcomp)));
-    if not(IsClosed(o)) then
+    if not IsClosed(o) then
         Info(InfoRecog,2,"D247:Obviously did not get normal subgroup!");
         return TemporaryFailure;
     fi;
@@ -364,7 +364,7 @@ FindHomMethodsProjective.D247 := function(ri,G)
     ngens := FastNormalClosure(GeneratorsOfGroup(G),[x],4);
     m := GModuleByMats(ngens,f);
     if MTX.IsIrreducible(m) then
-        if not(ispower) then
+        if not ispower then
             Info(InfoRecog,4,"Dimension is no power!");
             return fail; # FIXME: fail = TemporaryFailure here really correct?
         fi;
@@ -382,7 +382,7 @@ FindHomMethodsProjective.D247 := function(ri,G)
         od;
         nngens := FastNormalClosure(ngens,[y],2);
         mm := GModuleByMats(nngens,f);
-        if not(MTX.IsIrreducible(mm)) then
+        if not MTX.IsIrreducible(mm) then
             return RECOG.SortOutReducibleSecondNormalSubgroup(ri,G,nngens,mm);
         fi;
         return fail; # FIXME: fail = TemporaryFailure here really correct?
@@ -435,7 +435,7 @@ FindHomMethodsProjective.PrototypeForC2C4 := function(ri,G)
     local m,ngens;
     ngens := FastNormalClosure(GeneratorsOfGroup(G),x,4);
     m := GModuleByMats(ngens,f);
-    if not(IsIrreducible(m)) then
+    if not IsIrreducible(m) then
         Info(InfoRecog,2,"Proto: Seem to have found something!");
         return RECOG.SortOutReducibleNormalSubgroup(ri,G,ngens,m);
     else

--- a/gap/d247.gi
+++ b/gap/d247.gi
@@ -51,7 +51,7 @@ RECOG.CentralisingElementOfInvolution := function(pr,ord,x)
   if IsEvenInt(o) then
       return z^(o/2);
   fi;
-  return z^((o+1)/2)*r^(-1);
+  return z ^ ((o+1)/2) * (r^-1);
 end;
 
 RECOG.InvolutionCentraliser := function(pr, ord, x, nr)

--- a/gap/d247.gi
+++ b/gap/d247.gi
@@ -77,11 +77,9 @@ RECOG.InvolutionJumper := function(pr,ord,x,tol,withodd)
       o := ord(c);
       if o = 1 then
           continue;
-      fi;
-      if IsEvenInt(o) then
+      elif IsEvenInt(o) then
           return c^(o/2);
-      fi;
-      if not withodd then
+      elif not withodd then
           continue;
       fi;
       z := y*c^((o-1)/2);

--- a/gap/d247.gi
+++ b/gap/d247.gi
@@ -43,7 +43,9 @@ RECOG.CentralisingElementOfInvolution := function(pr,ord,x)
   r := Next(pr);
   y := x^r;
   # Now x and y generate a dihedral group
-  if x=y then return r; fi;
+  if x = y then
+      return r;
+  fi;
   z := x*y;
   o := ord(z);
   if IsEvenInt(o) then
@@ -73,11 +75,15 @@ RECOG.InvolutionJumper := function(pr,ord,x,tol,withodd)
       y := Next(pr);
       c := Comm(x,y);
       o := ord(c);
-      if o = 1 then continue; fi;
+      if o = 1 then
+          continue;
+      fi;
       if IsEvenInt(o) then
           return c^(o/2);
       fi;
-      if not(withodd) then continue; fi;
+      if not(withodd) then
+          continue;
+      fi;
       z := y*c^((o-1)/2);
       o := ord(z);
       if IsEvenInt(o) then

--- a/gap/d247.gi
+++ b/gap/d247.gi
@@ -53,15 +53,11 @@ RECOG.CentralisingElementOfInvolution := function(pr,ord,x)
   fi;
 end;
 
-RECOG.InvolutionCentraliser := function(pr,ord,x,nr)
-  # x an involution in G
-  local i,l,y;
-  l := [];
-  for i in [1..nr] do   # find 20 generators of the centraliser
-      y := RECOG.CentralisingElementOfInvolution(pr,ord,x);
-      AddSet(l,y);
-  od;
-  return l;
+RECOG.InvolutionCentraliser := function(pr, ord, x, nr)
+  # x is an involution in G.
+  # Choose <nr> elements (with possible repeats) of the centraliser of <x>,
+  # in the hope that they generate the centraliser.
+  return Set([1..nr], i -> RECOG.CentralisingElementOfInvolution(pr, ord, x));
 end;
 
 

--- a/gap/d247.gi
+++ b/gap/d247.gi
@@ -50,9 +50,8 @@ RECOG.CentralisingElementOfInvolution := function(pr,ord,x)
   o := ord(z);
   if IsEvenInt(o) then
       return z^(o/2);
-  else
-      return z^((o+1)/2)*r^(-1);
   fi;
+  return z^((o+1)/2)*r^(-1);
 end;
 
 RECOG.InvolutionCentraliser := function(pr, ord, x, nr)

--- a/gap/generic/FewGensAbelian.gi
+++ b/gap/generic/FewGensAbelian.gi
@@ -26,7 +26,9 @@ FindHomMethodsGeneric.FewGensAbelian := function(ri,G)
   local gens,i,j,l;
   gens := GeneratorsOfGroup(G);
   l := Length(gens);
-  if l > 200 then return NeverApplicable; fi;
+  if l > 200 then
+      return NeverApplicable;
+  fi;
   for i in [1..l-1] do
       for j in [i+1..l] do
           if not(ri!.isequal(gens[i]*gens[j],gens[j]*gens[i])) then

--- a/gap/generic/FewGensAbelian.gi
+++ b/gap/generic/FewGensAbelian.gi
@@ -19,11 +19,11 @@
 #! <Ref Subsect="KnownNilpotent" Style="Text"/>,
 #! otherwise return <K>NeverApplicable</K>.
 #! @EndChunk
-FindHomMethodsGeneric.FewGensAbelian := function(ri,G)
+FindHomMethodsGeneric.FewGensAbelian := function(ri, G)
   # If the number of generators is less than or equal to 200, then check
   # abelian and if so, hint to KnownNilpotent to write it as a direct
   # product of Sylow subgroups
-  local gens,i,j,l;
+  local gens, i, j, l;
   gens := GeneratorsOfGroup(G);
   l := Length(gens);
   if l > 200 then
@@ -37,5 +37,5 @@ FindHomMethodsGeneric.FewGensAbelian := function(ri,G)
       od;
   od;
   # We call KnownNilpotent:
-  return FindHomMethodsGeneric.KnownNilpotent(ri,G);
+  return FindHomMethodsGeneric.KnownNilpotent(ri, G);
 end;

--- a/gap/generic/FewGensAbelian.gi
+++ b/gap/generic/FewGensAbelian.gi
@@ -31,7 +31,7 @@ FindHomMethodsGeneric.FewGensAbelian := function(ri,G)
   fi;
   for i in [1..l-1] do
       for j in [i+1..l] do
-          if not(ri!.isequal(gens[i]*gens[j],gens[j]*gens[i])) then
+          if not ri!.isequal(gens[i] * gens[j], gens[j] * gens[i]) then
               return NeverApplicable;
           fi;
       od;

--- a/gap/matimpr.gi
+++ b/gap/matimpr.gi
@@ -79,7 +79,7 @@ RECOG.IndexMaxSub := function( hm, grp, d )
         orb := Orb(grp,sub,OnSubspacesByCanonicalBasis,
                    rec(storenumbers := true, hashlen := NextPrimeInt(8*d)));
         Enumerate(orb,4*d);
-        if not(IsClosed(orb)) then
+        if not IsClosed(orb) then
             Info(InfoRecog,2,"Did not find nice orbit.");
             if lastsub = fail then return fail; fi;
             return rec( orb := lastorb,
@@ -348,7 +348,7 @@ end;
 #FindHomMethodsMatrix.InducedOnSubspace := function(ri,G)
 #  local H,dim,gens,hom,newgens,gen,data;
 #  # Are we applicable?
-#  if not(IsBound(ri!.subdim)) then
+#  if not IsBound(ri!.subdim) then
 #      return NotEnoughInformation;
 #  fi;
 #

--- a/gap/matrix.gi
+++ b/gap/matrix.gi
@@ -564,8 +564,9 @@ FindHomMethodsMatrix.BlockDiagonal := function(ri,G)
   # Now give hints downward:
   forfactor(ri).blocks := ri!.blocks;
   Add(forfactor(ri).hints,
-      rec( method := FindHomMethodsProjective.BlocksModScalars,
-           rank := 2000, stamp := "BlocksModScalars" ) );
+      rec(method := FindHomMethodsProjective.BlocksModScalars,
+          rank   := 2000,
+          stamp  := "BlocksModScalars"));
   # We go to projective, although it would not matter here, because we
   # gave a working hint anyway:
   Setmethodsforfactor(ri,FindHomDbProjective);
@@ -579,10 +580,13 @@ FindHomMethodsMatrix.BlockDiagonal := function(ri,G)
   if ri!.projective then
       Add(forkernel(ri).hints,
           rec(method := FindHomMethodsProjective.BlockScalarProj,
-              rank := 2000,stamp := "BlockScalarProj"));
+              rank   := 2000,
+              stamp  := "BlockScalarProj"));
   else
-      Add(forkernel(ri).hints,rec(method := FindHomMethodsMatrix.BlockScalar,
-                                  rank := 2000,stamp := "BlockScalar"));
+      Add(forkernel(ri).hints,
+          rec(method := FindHomMethodsMatrix.BlockScalar,
+              rank   := 2000,
+              stamp  := "BlockScalar"));
   fi;
   forkernel(ri).blocks := ri!.blocks;
   return Success;

--- a/gap/matrix.gi
+++ b/gap/matrix.gi
@@ -472,7 +472,7 @@ end;
 
 # Homomorphism method used by FindHomMethodsMatrix.BlockLowerTriangular.
 RECOG.HomOntoBlockDiagonal := function(data,el)
-  local dim,i,m;
+  local m, x;
 
   # Verify el is in the domain of definition of this homomorphism.
   # Assuming the recognition result is correct, this is of course always
@@ -482,13 +482,10 @@ RECOG.HomOntoBlockDiagonal := function(data,el)
     return fail;
   fi;
 
-  dim := Length(el);
   m := ZeroMutable(el);
-  for i in [1..Length(data.blocks)] do
-      CopySubMatrix(el,m,data.blocks[i],data.blocks[i],
-                         data.blocks[i],data.blocks[i]);
+  for x in data.blocks do
+    CopySubMatrix(el, m, x, x, x, x);
   od;
-
   return m;
 end;
 

--- a/gap/matrix.gi
+++ b/gap/matrix.gi
@@ -172,13 +172,14 @@ end;
 # is valid -- that is, whether the rows and columns in
 # the set poss contain only zero elements outside of the
 # positions indicated by poss.
-RECOG.IsDiagonalBlockOfMatrix := function(mat,poss)
-  local z, i, j;
-  z := ZeroOfBaseDomain(mat);
+RECOG.IsDiagonalBlockOfMatrix := function(m, poss)
+  local n, outside, z, i, j;
+  Assert(1, NrRows(m) = NrCols(m) and IsSubset([1..NrRows(m)], poss));
+  outside := Difference([1..NrRows(m)], poss);
+  z := ZeroOfBaseDomain(m);
   for i in poss do
-    for j in [1..Length(mat)] do
-      if i in poss then continue; fi;
-      if mat[i,j] <> z or mat[j,i] <> z then
+    for j in outside do
+      if m[i,j] <> z or m[j,i] <> z then
         return false;
       fi;
     od;

--- a/gap/matrix.gi
+++ b/gap/matrix.gi
@@ -644,9 +644,8 @@ RECOG.ExtractLowStuff := function(m,layer,blocks,lens,basisOfFieldExtension)
       # SLPforElementFuncsMatrix.LowerLeftPGroup that we work
       # over a field of order p (not a p power)
       return BlownUpVector(basisOfFieldExtension, v);
-  else
-      return v;
   fi;
+  return v;
 end;
 
 RECOG.ComputeExtractionLayerLengths := function(blocks)
@@ -801,9 +800,8 @@ SLPforElementFuncsMatrix.LowerLeftPGroup := function(ri,g)
   od;
   if Length(l) = 0 then
       return StraightLineProgramNC([[1,0]],Length(ri!.gensNvectors));
-  else
-      return StraightLineProgramNC([l],Length(ri!.gensNvectors));
   fi;
+  return StraightLineProgramNC([l],Length(ri!.gensNvectors));
 end;
 
 #! @BeginChunk LowerLeftPGroup

--- a/gap/matrix.gi
+++ b/gap/matrix.gi
@@ -53,7 +53,7 @@ FindHomMethodsMatrix.DiagonalMatrices := function(ri, G)
       i := i + 1;
   od;
 
-  if not(isscalars) then
+  if not isscalars then
       # We quickly know that we want to make a balanced tree:
       ri!.blocks := List([1..d],i->[i]);
       # Note that we cannot tell the upper levels that they should better
@@ -133,7 +133,7 @@ FindHomMethodsMatrix.Scalar := function(ri, G)
   f := ri!.field;
   o := One(f);
   gens := List(GeneratorsOfGroup(G),x->x[1,1]);
-  subset := Filtered([1..Length(gens)],i->not(IsOne(gens[i])));
+  subset := Filtered([1..Length(gens)], i -> not IsOne(gens[i]));
   if subset = [] then
       return FindHomMethodsGeneric.TrivialGroup(ri,G);
   fi;
@@ -282,7 +282,7 @@ ExtendToBasisOfFullRowspace := function(m,f)
   # FIXME:
   # This function has to be improved with respect to performance:
   local i,o,v,z;
-  if not(IsMutable(m)) then
+  if not IsMutable(m) then
       m := MutableCopyMat(m);
   fi;
   v := ZeroMutable(m[1]);
@@ -600,7 +600,7 @@ end;
 #FindHomMethodsMatrix.InducedOnFactor := function(ri,G)
 #  local H,dim,gens,hom,newgens,gen,data;
 #  # Are we applicable?
-#  if not(IsBound(ri!.subdim)) then
+#  if not IsBound(ri!.subdim) then
 #      return NotEnoughInformation;
 #  fi;
 #
@@ -702,9 +702,9 @@ InstallGlobalFunction( FindKernelLowerLeftPGroup,
         i := 1;
         done := 0*[1..Length(lvec)];   # this refers to the current gens
         ready := false;
-        while not(ready) do
+        while not ready do
             # Find out where there is something left:
-            while pos > Length(v) and not(ready) do
+            while pos > Length(v) and not ready do
                 curlay := curlay + 1;
                 if curlay <= Length(lens) then
                     v := RECOG.ExtractLowStuff(x,curlay,ri!.blocks,lens,basisOfFieldExtension);
@@ -721,7 +721,7 @@ InstallGlobalFunction( FindKernelLowerLeftPGroup,
                 if pivots[i][1] = curlay then
                     # we might have jumped over a layer
                     done := -v[pivots[i][2]];
-                    if not(IsZero(done)) then
+                    if not IsZero(done) then
                         AddRowVector(v,lvec[i],done);
                         x := x * l[i]^IntFFE(done);
                     fi;
@@ -776,7 +776,7 @@ SLPforElementFuncsMatrix.LowerLeftPGroup := function(ri,g)
   # First project and calculate the vector:
   local done,h,i,l,layer,pow;
   # Take care of the projective case:
-  if ri!.projective and not(IsOne(g[1,1])) then
+  if ri!.projective and not IsOne(g[1,1]) then
       g := (g[1,1]^-1) * g;
   fi;
   l := [];
@@ -786,7 +786,7 @@ SLPforElementFuncsMatrix.LowerLeftPGroup := function(ri,g)
                                  ri!.basisOfFieldExtension);
       while i <= Length(ri!.gensNvectors) and ri!.gensNpivots[i][1] = layer do
           done := h[ri!.gensNpivots[i][2]];
-          if not(IsZero(done)) then
+          if not IsZero(done) then
               AddRowVector(h,ri!.gensNvectors[i],-done);
               pow := IntFFE(done);
               g := NiceGens(ri)[i]^(-pow) * g;
@@ -901,7 +901,7 @@ end;
 #  v := FullRowSpace(f,d);
 #  repeat
 #      w := Random(v);
-#  until not(IsZero(w));
+#  until not IsZero(w);
 #  o := Orbit(G,w,OnRight);
 #  hom := ActionHomomorphism(G,o,OnRight);
 #

--- a/gap/matrix.gi
+++ b/gap/matrix.gi
@@ -423,7 +423,9 @@ FindHomMethodsMatrix.ReducibleIso := function(ri,G)
   # Save the MeatAxe module for later use:
   ri!.meataxemodule := m;
   # Report enduring failure if irreducible:
-  if isirred then return NeverApplicable; fi;
+  if isirred then
+      return NeverApplicable;
+  fi;
 
   # Now compute a composition series:
   compseries := MTX.BasesCompositionSeries(m);
@@ -793,7 +795,9 @@ SLPforElementFuncsMatrix.LowerLeftPGroup := function(ri,g)
           fi;
           i := i + 1;
       od;
-      if not(IsZero(h)) then return fail; fi;
+      if not IsZero(h) then
+          return fail;
+      fi;
   od;
   if Length(l) = 0 then
       return StraightLineProgramNC([[1,0]],Length(ri!.gensNvectors));

--- a/gap/matrix.gi
+++ b/gap/matrix.gi
@@ -212,7 +212,7 @@ end;
 #! will only be scalar matrices. This method recursively builds a balanced tree
 #! and does scalar recognition in each leaf.
 #! @EndChunk
-FindHomMethodsMatrix.BlockScalar := function(ri,G)
+FindHomMethodsMatrix.BlockScalar := function(ri, G)
   # We assume that ri!.blocks is a list of ranges where the non-trivial
   # scalar blocks are. Note that their length does not have to sum up to
   # the dimension, because some blocks at the end might already be trivial.
@@ -558,9 +558,7 @@ FindHomMethodsMatrix.BlockDiagonal := function(ri,G)
   # We do all the blocks projectively and thus are left with scalar blocks.
   # In the projective case we still do the same, the BlocksModScalars
   # will automatically take care of the projectiveness!
-  local hom;
-  hom := IdentityMapping(G);
-  SetHomom(ri,hom);
+  SetHomom(ri, IdentityMapping(G));
   # Now give hints downward:
   forfactor(ri).blocks := ri!.blocks;
   Add(forfactor(ri).hints,
@@ -803,9 +801,9 @@ SLPforElementFuncsMatrix.LowerLeftPGroup := function(ri,g)
       fi;
   od;
   if Length(l) = 0 then
-      return StraightLineProgramNC([[1,0]],Length(ri!.gensNvectors));
+      l := [1, 0];
   fi;
-  return StraightLineProgramNC([l],Length(ri!.gensNvectors));
+  return StraightLineProgramNC([l], Length(ri!.gensNvectors));
 end;
 
 #! @BeginChunk LowerLeftPGroup
@@ -819,9 +817,11 @@ end;
 FindHomMethodsMatrix.LowerLeftPGroup := function(ri,G)
   local f,p;
   # Do we really have our favorite situation?
-  if not(IsBound(ri!.blocks) and IsBound(ri!.lens) and
-         IsBound(ri!.basisOfFieldExtension) and IsBound(ri!.gensNvectors) and
-         IsBound(ri!.gensNpivots)) then
+  if not (IsBound(ri!.blocks) and
+          IsBound(ri!.lens) and
+          IsBound(ri!.basisOfFieldExtension) and
+          IsBound(ri!.gensNvectors) and
+          IsBound(ri!.gensNpivots)) then
       return NotEnoughInformation;
   fi;
   # We are done, because we can do linear algebra:

--- a/gap/perm.gi
+++ b/gap/perm.gi
@@ -200,7 +200,7 @@ end;
 # gives an error if not.
 DoSafetyCheckStabChain := function(S)
   while IsBound(S.stabilizer) do
-      if not(IsIdenticalObj(S.labels,S.stabilizer.labels)) then
+      if not IsIdenticalObj(S.labels, S.stabilizer.labels) then
           ErrorNoReturn("Alert! labels not identical on different levels!");
       fi;
       S := S.stabilizer;
@@ -272,13 +272,13 @@ end;
 # from the stabilizer chain <S>
 WordinLabels := function(word,S,g)
   local i,point,start;
-  if not(IsBound(S.orbit) and IsBound(S.orbit[1])) then
+  if not (IsBound(S.orbit) and IsBound(S.orbit[1])) then
       return fail;
   fi;
   start := S.orbit[1];
   point := start^g;
   while point <> start do
-      if not(IsBound(S.translabels[point])) then
+      if not IsBound(S.translabels[point]) then
           return fail;
       fi;
       i := S.translabels[point];
@@ -288,7 +288,7 @@ WordinLabels := function(word,S,g)
   od;
   # now g is in the first stabilizer
   if g <> S.identity then
-      if not(IsBound(S.stabilizer)) then
+      if not IsBound(S.stabilizer) then
           return fail;
       fi;
       return WordinLabels(word,S.stabilizer,g);

--- a/gap/perm.gi
+++ b/gap/perm.gi
@@ -318,9 +318,9 @@ SLPinLabels := function(S,g)
   od;
   l := Length(S!.labels);
   if Length(word) = 0 then
-      return StraightLineProgramNC( [ [1,0] ], l );
+      return StraightLineProgramNC([[1, 0]], l);
   fi;
-  return StraightLineProgramNC( [ line, [l+1,-1] ], l );
+  return StraightLineProgramNC([line, [l + 1, -1]], l);
 end;
 
 

--- a/gap/perm.gi
+++ b/gap/perm.gi
@@ -319,9 +319,8 @@ SLPinLabels := function(S,g)
   l := Length(S!.labels);
   if Length(word) = 0 then
       return StraightLineProgramNC( [ [1,0] ], l );
-  else
-      return StraightLineProgramNC( [ line, [l+1,-1] ], l );
   fi;
+  return StraightLineProgramNC( [ line, [l+1,-1] ], l );
 end;
 
 
@@ -344,9 +343,8 @@ StoredPointsPerm := function(p)
       return s/4;   # permutation stored with 4 bytes per point
   elif IsPerm2Rep(p) then
       return s/2;   # permutation stored with 2 bytes per point
-  else
-      ErrorNoReturn("StoredPointsPerm: input is not an internal permutation");
   fi;
+  ErrorNoReturn("StoredPointsPerm: input is not an internal permutation");
 end;
 
 #! @BeginChunk ThrowAwayFixedPoints

--- a/gap/tensor.gi
+++ b/gap/tensor.gi
@@ -63,7 +63,7 @@ RECOG.FindTensorKernel := function(G,onlyone)
       N := GroupWithGenerators(FastNormalClosure(GeneratorsOfGroup(G),[c],10));
       if onlyone and
          (ForAny(GeneratorsOfGroup(N),m->IsZero(m[1,1]) or
-                                         not(IsOne(m*(m[1,1])^-1)))) then
+                                         not IsOne(m*(m[1,1])^-1))) then
           # we found a non-scalar normal subgroup:
           #Print("\n");
           return N;
@@ -148,7 +148,7 @@ RECOG.FindTensorDecomposition := function(G,N)
   while Length(h) < d/Length(homsimg) and i <= Length(l) do
       for g in gens do
           c := OnSubspacesByCanonicalBasis(l[i],g);
-          if not(c in lset) then
+          if not c in lset then
               Add(h,h[i]*g);
               Add(l,c);
               AddSet(lset,c);
@@ -360,7 +360,7 @@ FindHomMethodsProjective.TensorDecomposable := function(ri,G)
   # Now we believe to have a tensor decomposition:
   conjgensG := List(GeneratorsOfGroup(G),x->r.t * x * r.ti);
   kro := List(conjgensG,g->RECOG.IsKroneckerProduct(g,r.blocksize));
-  if not(ForAll(kro,k->k[1] = true)) then
+  if not ForAll(kro, k -> k[1]) then
       Info(InfoRecog,1,"VERY, VERY, STRANGE!");
       Info(InfoRecog,1,"False alarm, was not a tensor decomposition.",
            " Found at least a perm action.");

--- a/gap/tools.gi
+++ b/gap/tools.gi
@@ -52,8 +52,8 @@ RECOG.ElementOrderStats := function(pr,order,n,k)
   od;
   pos := PositionSorted(sums,QuoInt(n,2));
   return rec( exponent := Lcm(ords), colorders := col,
-              allorders := Set(List(col,x->x[1])),
-              freqorders := Set(List(col{[1..pos]},x->x[1])),
+              allorders := Set(col,x->x[1]),
+              freqorders := Set(col{[1..pos]},x->x[1]),
               probability := sums[pos] / n, samplesize := n,
               independencek := k );
 end;

--- a/gap/tools.gi
+++ b/gap/tools.gi
@@ -86,7 +86,7 @@ RECOG.CheckFingerPrint := function(fp,orders)
         if ForAny(orders,o->fp.size mod o <> 0) then return 0; fi;
     fi;
     if IsBound(fp.allorders) then
-        if ForAny(orders,o->not(o in fp.allorders)) then return 0; fi;
+        if ForAny(orders,o->not o in fp.allorders) then return 0; fi;
     fi;
     count := Number(orders,o->o in fp.freqorders);
     return RECOG.BinomialTab[Length(orders)][count+1]/2^(Length(orders));

--- a/gap/tools.gi
+++ b/gap/tools.gi
@@ -51,11 +51,15 @@ RECOG.ElementOrderStats := function(pr,order,n,k)
       Add(sums,sums[i-1] + col[i][2]);
   od;
   pos := PositionSorted(sums,QuoInt(n,2));
-  return rec( exponent := Lcm(ords), colorders := col,
-              allorders := Set(col,x->x[1]),
-              freqorders := Set(col{[1..pos]},x->x[1]),
-              probability := sums[pos] / n, samplesize := n,
-              independencek := k );
+  return rec(
+             allorders     := Set(col, x -> x[1]),
+             colorders     := col,
+             exponent      := Lcm(ords),
+             freqorders    := Set(col{[1..pos]}, x -> x[1]),
+             independencek := k,
+             probability   := sums[pos] / n,
+             samplesize    := n,
+            );
 end;
 
 RECOG.BinomialTab := [];


### PR DESCRIPTION
I looked through several files one evening last week, and for fun I started to make some mostly superficial changes as I went along. The idea with this PR is to go some small way to making the code in the package more readable, and also more consistent with what I know of the GAP world. Sorry if this is overwhelming to review.

Here are the main things that I've done:
* I broke one-line conditions `if condition then something; fi;` into three-liners.
* I removed brackets around simple negations, i.e. `not(single_condition)` -> `not single_condition`.
* I joined some consecutive and compatible `if ... fi; if ... fi;` bits of code with `elif`s.
* I used `StringFormatted` to clean up some messy `Info` messages.
* I slightly improved `RECOG.IsDiagonalBlockOfMatrix` in `gap/matrix.gi`.
* I corrected a comment in `RECOG.InvolutionCentraliser` in `gap/d247.gi`.
* I changed `return false;` to `return NeverApplicable;` in `FindHomMethodsProjective.Subfield`.
* I replaced some `Set(List(...` calls with `Set(...`.
* ~~I replaced a `List[Length(list)]` with `Last(list)`.~~
* I simplified some code in other ways, where I saw an opportunity to do so.

I also changed these somewhat more subjective things, simply because I wanted to:
* I made some record definitions line up nicely.
* ~~`Length(variable) = 0` to `IsEmpty(variable)`.~~
* ~~`Length(variable) > 0` to `not IsEmpty(variable)`.~~
* A few other spacing tweaks (sorry)
* I removed some final `else`s from the end of functions, i.e.
```gap
if condition then
  return value;
else
  return other;
fi;
```
becomes
```gap
if condition then
  return value;
fi;
return other;
```