### PR TITLE
Improve referencing in documentation in some parts of perm.gi

### DIFF
--- a/gap/perm.gi
+++ b/gap/perm.gi
@@ -120,12 +120,12 @@ FindHomMethodsPerm.Imprimitive :=
 
 #! @BeginChunk PcgsForBlocks
 #! This method is called after a hint is set in
-#! <Ref Subsect="Imprimitive" Style="Text"/>.
+#! <C>FindHomMethodsPerm.</C><Ref Subsect="Imprimitive" Style="Text"/>.
 #! Therefore, the group <A>G</A> preserves a non-trivial block system.
 #! This method checks whether or not the restriction of <A>G</A> on one block
 #! is solvable.
-#! If so, then <Ref Subsect="Pcgs" Style="Text"/> is called,
-#! and otherwise <K>NeverApplicable</K> is returned.
+#! If so, then <C>FindHomMethodsPerm.</C><Ref Subsect="Pcgs" Style="Text"/> is
+#! called, and otherwise <K>NeverApplicable</K> is returned.
 #! @EndChunk
 FindHomMethodsPerm.PcgsForBlocks := function(ri,G)
   local blocks,pcgs,subgens;
@@ -144,8 +144,8 @@ end;
 #! @BeginChunk BalTreeForBlocks
 #! This method creates a balanced composition tree for the kernel of an
 #! imprimitive group. This is guaranteed as the method is just called
-#! from <Ref Subsect="Imprimitive" Style="Text"/> and itself.
-#! The homomorphism for the split in the composition tree used is
+#! from <C>FindHomMethodsPerm.</C><Ref Subsect="Imprimitive" Style="Text"/>
+#! and itself. The homomorphism for the split in the composition tree used is
 #! induced by the action of <A>G</A> on
 #! half of its blocks.
 #! @EndChunk


### PR DESCRIPTION
In #131 @PaulaHaehndel and co-authors added things like `<C>FindHomMethodsPerm.Imprimitive</C>` to certain parts of the autodoc documentation. I came along and blithely changed this to `<Ref Subsect="Imprimitive" Style="Text"/>` and similar, dropping the `FindHomMethodsPerm` bit. But I have now learnt that it was a deliberate choice to include in #131 (see https://github.com/gap-packages/recog/pull/131#discussion_r301122826)

I've tried to find a compromise. How do we feel about this? It renders fine in the manual, and I think looks fine in the code too. If we like it, I can do this in other appropriate places of the documentation.