### PR TITLE
Don't call RANDOM_SEED; Update Randomize installation to future GAP versions

### DIFF
--- a/gap/base/hack.g
+++ b/gap/base/hack.g
@@ -54,11 +54,15 @@ InstallMethod( PseudoRandom, "for a group object with generators, use func",
 # than 256 elements; needed by RECOG.RuleOutSmallProjOrder
 InstallOtherMethod( Randomize, "for a mutable FFE vector",
   [ IsFFECollection and IsPlistRep and IsMutable ],
-  v -> Randomize(v, GlobalMersenneTwister));
+  v -> Randomize(GlobalMersenneTwister, v));
 
 InstallOtherMethod( Randomize, "for a mutable FFE vector and a random source",
   [ IsFFECollection and IsPlistRep and IsMutable, IsRandomSource ],
-  function( v, rs )
+  { v, rs } -> Randomize(rs, v) );
+
+InstallOtherMethod( Randomize, "for a random source and a mutable FFE vector",
+  [ IsRandomSource, IsFFECollection and IsPlistRep and IsMutable ],
+  function( rs, v )
     local f,i;
     f := DefaultField(v);
     for i in [1..Length(v)] do v[i] := Random(rs,f); od;

--- a/tst/testall.g
+++ b/tst/testall.g
@@ -6,7 +6,7 @@ LoadPackage("recog");
 # precisely so that we can catch issues that only appear with some RNG
 # states, but not with others.
 FlushCaches(  );
-RANDOM_SEED( 1 );
+Reset(GlobalRandomSource, 1);
 Reset( GlobalMersenneTwister, 1 );
 
 TestDirectory(DirectoriesPackageLibrary("recog", "tst/working"), rec(exitGAP := true));


### PR DESCRIPTION
The order of the random source and the matrix/vector will be swapped, to match
the order used by `Random` and other similar functions. The code in this
commit should work equally well with old and new GAP versions.
