### PR TITLE
Fix doc/clean script

### DIFF
--- a/doc/clean
+++ b/doc/clean
@@ -1,4 +1,21 @@
 #!/bin/sh
 
-rm -f *.{aux,lab,log,dvi,ps,pdf,bbl,ilg,ind,idx,out,html,tex,pnr,txt,blg,toc,six,brf}
-
+rm -f *.aux
+rm -f *.lab
+rm -f *.log
+rm -f *.dvi
+rm -f *.ps
+rm -f *.pdf
+rm -f *.bbl
+rm -f *.ilg
+rm -f *.ind
+rm -f *.idx
+rm -f *.out
+rm -f *.html
+rm -f *.tex
+rm -f *.pnr
+rm -f *.txt
+rm -f *.blg
+rm -f *.toc
+rm -f *.six
+rm -f *.brf


### PR DESCRIPTION
My `/bin/sh` does not understand the *.{a,b,c} expansion. Is there a cleverer way to resolve this issue?