### PR TITLE
Extend AddMethod

### DIFF
--- a/doc/methsel.xml
+++ b/doc/methsel.xml
@@ -82,8 +82,9 @@ a record with the following components bound:
 
 The different methods for a certain task are collected in so-called
 <Q>method databases</Q>. A <E>method database</E> is just a list of records,
-each describing a method in the format described above. Usually, the
-ranks will be descending, but that is not necessary.<P/>
+each describing a method in the format described above. During method selection,
+the methods are tried in the order in which they are stored in the database.
+Thus they should be stored in rank-descending order.<P/>
 
 There is one convenience function to put a new method into a method database:
 

--- a/doc/methsel.xml
+++ b/doc/methsel.xml
@@ -57,7 +57,7 @@ one of the following four values:<P/>
 <Mark><K>NotEnoughInformation</K></Mark>
 <Item>means that the method for some reason refused to do its work. However,
     it is possible that it will become applicable later such that it makes
-    sense to call it again, may when more information is available.</Item>
+    sense to call it again, for example when more information is available.</Item>
 </List>
 
 For administration in the method selection, a method is described by

--- a/gap/base/methsel.gd
+++ b/gap/base/methsel.gd
@@ -17,9 +17,13 @@
 #############################################################################
 
 # Our own method selection code:
-
 DeclareInfoClass( "InfoMethSel" );
 SetInfoLevel(InfoMethSel,1);
+
+# InfoClass so that we can for example check whether every method checks
+# whether its input is valid.
+DeclareInfoClass( "InfoAddMethod" );
+SetInfoLevel(InfoAddMethod, 0);
 
 ## <#GAPDoc Label="AddMethod">
 ## <ManSection>

--- a/gap/base/methsel.gd
+++ b/gap/base/methsel.gd
@@ -23,15 +23,20 @@ SetInfoLevel(InfoMethSel,1);
 
 ## <#GAPDoc Label="AddMethod">
 ## <ManSection>
-## <Func Name="AddMethod" Arg="db, meth, rank, stamp [,comment]"/>
+## <Func Name="AddMethod" Arg="methodDb, method"/>
 ## <Returns>nothing</Returns>
 ## <Description>
-##     <A>db</A> must be a method database (list of records, see above) with
-##     non-ascending rank values. <A>meth</A> is the method function,
-##     <A>rank</A> the rank and <A>stamp</A> a string valued stamp. The
-##     optional argument <A>comment</A> can be a string comment. The record
-##     describing the method is created and inserted at the correct position
-##     in the method database. Nothing is returned.
+#  <A>methodDb</A> must be a method database as in Section
+#  <Ref Sect="whataremethods"/>.
+#  <A>method</A> must be a record with the following components.
+#  <A>method</A> is the method function,
+#  <A>rank</A> the rank and <A>stamp</A> a string valued stamp, that is
+#  <A>stamp</A> uniquely identifies the method among all other methods.
+#  Optionally the component <A>comment</A> can be bound to a string.
+#  <P/>
+#  The method record <A>method</A> is inserted according to its rank, assuming
+#  that the method database <A>methodDb</A> is in rank-descending order.
+#  Nothing is returned.
 ## </Description>
 ## </ManSection>
 ## <#/GAPDoc>

--- a/gap/base/methsel.gi
+++ b/gap/base/methsel.gi
@@ -30,6 +30,12 @@ InstallGlobalFunction("AddMethod", function(methodDb, method)
     if not IsBound(method.comment) then
         method.comment := "";
     fi;
+    # method.validatesOrAlwaysValidInput for now only stores meta-information.
+    # It may be used in the future, see github issue #184.
+    if not IsBound(method.validatesOrAlwaysValidInput) then
+        Info(InfoAddMethod, 1, "AddMethod, ", method.stamp,
+             ": validatesOrAlwaysValidInput not bound");
+    fi;
     l := Length(methodDb);
     pos := First([1 .. l], i -> methodDb[i].rank <= method.rank);
     if pos = fail then

--- a/gap/base/methsel.gi
+++ b/gap/base/methsel.gi
@@ -20,28 +20,22 @@
 # Add a method to a database with "AddMethod" and call a method from a
 # database with "CallMethods".
 #
-InstallGlobalFunction( "AddMethod", function(arg)
-  # First argument is the method database, second is the method itself,
-  # third is the rank, fourth is the stamp. An optional 5th argument is
-  # the comment.
-  local comment,db,i,l,mr,p;
-  if Length(arg) < 4 or Length(arg) > 5 then
-      ErrorNoReturn("Usage: AddMethod(database,method,rank,stamp [,comment] );");
-  fi;
-  db := arg[1];
-  mr := rec(method := arg[2],rank := arg[3],stamp := arg[4]);
-  if Length(arg) = 5 then
-      mr.comment := arg[5];
-  else
-      mr.comment := "";
-  fi;
-  l := Length(db);
-  p := First([1..l],i->db[i].rank <= mr.rank);
-  if p = fail then
-      Add(db,mr);
-  else
-      Add(db,mr,p);
-  fi;
+InstallGlobalFunction("AddMethod", function(methodDb, method)
+    local l, pos;
+    if not IsSubsetSet(NamesOfComponents(method),
+                       ["method", "rank", "stamp"]) then
+        ErrorNoReturn("<method> must have components",
+                      " method, rank, and stamp");
+    fi;
+    if not IsBound(method.comment) then
+        method.comment := "";
+    fi;
+    l := Length(methodDb);
+    pos := First([1 .. l], i -> methodDb[i].rank <= method.rank);
+    if pos = fail then
+        pos := l + 1;
+    fi;
+    Add(methodDb, method, pos);
 end);
 
 

--- a/gap/example/cyclic2.gi
+++ b/gap/example/cyclic2.gi
@@ -3,7 +3,7 @@
 ############################################################################
 
 FindHomMethodsPerm.Cyclic2 :=
-   function(ri,H)
+   function(ri, H)
      local gens,i;
      # Test applicability (this would no longer be necessary, because we
      # are called only for permutation groups anyway. However, this is an
@@ -32,18 +32,19 @@ FindHomMethodsPerm.Cyclic2 :=
    end;
 
 SLPforElementFuncsPerm.Cyclic2 :=
-   function( ri, g )
+   function(ri, g)
      if IsOne(g) then
-         return StraightLineProgram( [ [1,0] ], 1 );
+         return StraightLineProgram([[1, 0]], 1);
      else
-         return StraightLineProgram( [ [1,1] ], 1 );
+         return StraightLineProgram([[1, 1]], 1);
      fi;
    end;
 
 # The following would install this method with a very low rank if we would
 # like to:
 #
-# AddMethod( FindHomDbPerm, FindHomMethodsPerm.Cyclic2,
-#            1, "Cyclic2",
-#            "cheat: find a Cyclic2" );
-
+# AddMethod(FindHomDbPerm,
+#           rec(method := FindHomMethodsPerm.Cyclic2,
+#               rank := 1,
+#               stamp := "Cyclic2",
+#               comment := "find a Cyclic2"));

--- a/gap/matrix.gi
+++ b/gap/matrix.gi
@@ -932,24 +932,65 @@ end;
 #  return true;
 #end;
 
-AddMethod( FindHomDbMatrix, FindHomMethodsGeneric.TrivialGroup,
-  3100, "TrivialGroup",
-        "check whether all generators are equal to the identity matrix" );
-AddMethod( FindHomDbMatrix, FindHomMethodsMatrix.DiagonalMatrices,
-  1100, "DiagonalMatrices",
-        "check whether all generators are diagonal matrices" );
-AddMethod( FindHomDbMatrix, FindHomMethodsMatrix.KnownStabilizerChain,
-  1175, "KnownStabilizerChain",
-        "use an already known stabilizer chain for this group" );
-AddMethod( FindHomDbMatrix, FindHomMethodsGeneric.FewGensAbelian,
-  1050, "FewGensAbelian",
-     "if very few generators, check IsAbelian and if yes, do KnownNilpotent");
-AddMethod( FindHomDbMatrix, FindHomMethodsMatrix.ReducibleIso,
-  1000, "ReducibleIso",
-        "use the MeatAxe to find invariant subspaces" );
-AddMethod( FindHomDbMatrix, FindHomMethodsMatrix.GoProjective,
-   900, "GoProjective",
-        "divide out scalars and recognise projectively" );
+AddMethod(
+    FindHomDbMatrix,
+    rec(
+        method := FindHomMethodsGeneric.TrivialGroup,
+        rank := 3100,
+        stamp := "TrivialGroup",
+        comment := "check whether all generators are equal to the identity matrix",
+    )
+);
+
+AddMethod(
+    FindHomDbMatrix,
+    rec(
+        method := FindHomMethodsMatrix.DiagonalMatrices,
+        rank := 1100,
+        stamp := "DiagonalMatrices",
+        comment := "check whether all generators are diagonal matrices",
+    )
+);
+
+AddMethod(
+    FindHomDbMatrix,
+    rec(
+        method := FindHomMethodsMatrix.KnownStabilizerChain,
+        rank := 1175,
+        stamp := "KnownStabilizerChain",
+        comment := "use an already known stabilizer chain for this group",
+    )
+);
+
+AddMethod(
+    FindHomDbMatrix,
+    rec(
+        method := FindHomMethodsGeneric.FewGensAbelian,
+        rank := 1050,
+        stamp := "FewGensAbelian",
+        comment := "if very few generators, check IsAbelian and if yes, do KnownNilpotent",
+    )
+);
+
+AddMethod(
+    FindHomDbMatrix,
+    rec(
+        method := FindHomMethodsMatrix.ReducibleIso,
+        rank := 1000,
+        stamp := "ReducibleIso",
+        comment := "use the MeatAxe to find invariant subspaces",
+    )
+);
+
+AddMethod(
+    FindHomDbMatrix,
+    rec(
+        method := FindHomMethodsMatrix.GoProjective,
+        rank := 900,
+        stamp := "GoProjective",
+        comment := "divide out scalars and recognise projectively",
+    )
+);
 
 ###AddMethod( FindHomDbMatrix, FindHomMethodsMatrix.SmallVectorSpace,
 ###           700, "SmallVectorSpace",

--- a/gap/matrix/classical.gi
+++ b/gap/matrix/classical.gi
@@ -2094,80 +2094,218 @@ end;
 #
 # 1 - 10 Workers
 
-AddMethod( ClassicalMethDb, RECOG.TestRandomElement, 100, "TestRandomElement",
-           "makes new random element and stores it and its char poly" );
+AddMethod(
+    ClassicalMethDb,
+    rec(
+        method := RECOG.TestRandomElement,
+        rank := 100,
+        stamp := "TestRandomElement",
+        comment := "makes new random element and stores it and its char poly",
+    )
+);
 
-AddMethod( ClassicalMethDb, RECOG.IsGenericParameters,90,"IsGenericParameters",
-           "tests whether group has generic parameters" );
+AddMethod(
+    ClassicalMethDb,
+    rec(
+        method := RECOG.IsGenericParameters,
+        rank := 90,
+        stamp := "IsGenericParameters",
+        comment := "tests whether group has generic parameters",
+    )
+);
 
-AddMethod( ClassicalMethDb, RECOG.IsGeneric, 89, "IsGeneric",
-           "tests whether group is generic" );
+AddMethod(
+    ClassicalMethDb,
+    rec(
+        method := RECOG.IsGeneric,
+        rank := 89,
+        stamp := "IsGeneric",
+        comment := "tests whether group is generic",
+    )
+);
 
-AddMethod( ClassicalMethDb, RECOG.IsReducible, 80, "IsReducible",
-           "tests whether current random element rules out reducible" );
+AddMethod(
+    ClassicalMethDb,
+    rec(
+        method := RECOG.IsReducible,
+        rank := 80,
+        stamp := "IsReducible",
+        comment := "tests whether current random element rules out reducible",
+    )
+);
 
-AddMethod( ClassicalMethDb, RECOG.RuledOutExtField, 81,
-           "RuledOutExtField",
-           "tests whether extension field case is ruled out" );
+AddMethod(
+    ClassicalMethDb,
+    rec(
+        method := RECOG.RuledOutExtField,
+        rank := 81,
+        stamp := "RuledOutExtField",
+        comment := "tests whether extension field case is ruled out",
+    )
+);
 
-AddMethod( ClassicalMethDb, RECOG.IsNotMathieu, 82,
-           "IsNotMathieu",
-           "tests whether Mathieu groups are ruled out" );
+AddMethod(
+    ClassicalMethDb,
+    rec(
+        method := RECOG.IsNotMathieu,
+        rank := 82,
+        stamp := "IsNotMathieu",
+        comment := "tests whether Mathieu groups are ruled out",
+    )
+);
 
-AddMethod( ClassicalMethDb, RECOG.IsNotAlternating, 83,
-           "IsNotAlternating",
-           "tests whether alternating groups are ruled out" );
+AddMethod(
+    ClassicalMethDb,
+    rec(
+        method := RECOG.IsNotAlternating,
+        rank := 83,
+        stamp := "IsNotAlternating",
+        comment := "tests whether alternating groups are ruled out",
+    )
+);
 
-AddMethod( ClassicalMethDb, RECOG.IsNotPSL, 84,
-           "IsNotPSL",
-           "tests whether PSL groups are ruled out" );
-
-
-AddMethod( ClassicalMethDb, RECOG.NoClassicalForms, 85,
-           "NoClassicalForms",
-           "tests whether we can rule out certain forms" );
-
-AddMethod( ClassicalMethDb, RECOG.MeatAxe, 9,
-           "MeatAxe", "Test irreducibility" );
-
-AddMethod( ClassicalMethDb, RECOG.ClassicalForms, 8 ,
-           "ClassicalForms", "Find the invariant forms" );
-
-AddMethod( ClassicalMethDb, RECOG.NonGenericLinear, 10, "NonGenericLinear",
-           "tests whether group is non-generic Linear" );
-
-AddMethod( ClassicalMethDb, RECOG.NonGenericUnitary, 11, "NonGenericUnitary",
-           "tests whether group is non-generic Unitary" );
-
-AddMethod( ClassicalMethDb, RECOG.NonGenericSymplectic, 12,
-            "NonGenericSymplectic",
-           "tests whether group is non-generic Symplectic" );
-
-AddMethod( ClassicalMethDb, RECOG.NonGenericOrthogonalPlus, 13,
-           "NonGenericOrthogonalPlus",
-           "tests whether group is non-generic O+" );
-
-
-AddMethod( ClassicalMethDb, RECOG.NonGenericOrthogonalMinus, 14,
-           "NonGenericOrthogonalMinus",
-           "tests whether group is non-generic O-" );
+AddMethod(
+    ClassicalMethDb,
+    rec(
+        method := RECOG.IsNotPSL,
+        rank := 84,
+        stamp := "IsNotPSL",
+        comment := "tests whether PSL groups are ruled out",
+    )
+);
 
 
-AddMethod( ClassicalMethDb, RECOG.NonGenericOrthogonalCircle, 15,
-           "NonGenericOrthogonalCircle",
-           "tests whether group is non-generic Oo" );
+AddMethod(
+    ClassicalMethDb,
+    rec(
+        method := RECOG.NoClassicalForms,
+        rank := 85,
+        stamp := "NoClassicalForms",
+        comment := "tests whether we can rule out certain forms",
+    )
+);
 
-AddMethod( ClassicalMethDb, RECOG.IsSLContained, 16, "IsSLContained",
-           "tests whether group contains SL" );
+AddMethod(
+    ClassicalMethDb,
+    rec(
+        method := RECOG.MeatAxe,
+        rank := 9,
+        stamp := "MeatAxe",
+        comment := "Test irreducibility",
+    )
+);
 
-AddMethod( ClassicalMethDb, RECOG.IsSpContained, 17, "IsSpContained",
-           "tests whether group contains Sp" );
+AddMethod(
+    ClassicalMethDb,
+    rec(
+        method := RECOG.ClassicalForms,
+        rank := 8,
+        stamp := "ClassicalForms",
+        comment := "Find the invariant forms",
+    )
+);
 
-AddMethod( ClassicalMethDb, RECOG.IsSUContained, 18, "IsSUContained",
-           "tests whether group contains SU" );
+AddMethod(
+    ClassicalMethDb,
+    rec(
+        method := RECOG.NonGenericLinear,
+        rank := 10,
+        stamp := "NonGenericLinear",
+        comment := "tests whether group is non-generic Linear",
+    )
+);
 
-AddMethod( ClassicalMethDb, RECOG.IsSOContained, 19, "IsSOContained",
-           "tests whether group contains SO" );
+AddMethod(
+    ClassicalMethDb,
+    rec(
+        method := RECOG.NonGenericUnitary,
+        rank := 11,
+        stamp := "NonGenericUnitary",
+        comment := "tests whether group is non-generic Unitary",
+    )
+);
+
+AddMethod(
+    ClassicalMethDb,
+    rec(
+        method := RECOG.NonGenericSymplectic,
+        rank := 12,
+        stamp := "NonGenericSymplectic",
+        comment := "tests whether group is non-generic Symplectic",
+    )
+);
+
+AddMethod(
+    ClassicalMethDb,
+    rec(
+        method := RECOG.NonGenericOrthogonalPlus,
+        rank := 13,
+        stamp := "NonGenericOrthogonalPlus",
+        comment := "tests whether group is non-generic O+",
+    )
+);
+
+
+AddMethod(
+    ClassicalMethDb,
+    rec(
+        method := RECOG.NonGenericOrthogonalMinus,
+        rank := 14,
+        stamp := "NonGenericOrthogonalMinus",
+        comment := "tests whether group is non-generic O-",
+    )
+);
+
+
+AddMethod(
+    ClassicalMethDb,
+    rec(
+        method := RECOG.NonGenericOrthogonalCircle,
+        rank := 15,
+        stamp := "NonGenericOrthogonalCircle",
+        comment := "tests whether group is non-generic Oo",
+    )
+);
+
+AddMethod(
+    ClassicalMethDb,
+    rec(
+        method := RECOG.IsSLContained,
+        rank := 16,
+        stamp := "IsSLContained",
+        comment := "tests whether group contains SL",
+    )
+);
+
+AddMethod(
+    ClassicalMethDb,
+    rec(
+        method := RECOG.IsSpContained,
+        rank := 17,
+        stamp := "IsSpContained",
+        comment := "tests whether group contains Sp",
+    )
+);
+
+AddMethod(
+    ClassicalMethDb,
+    rec(
+        method := RECOG.IsSUContained,
+        rank := 18,
+        stamp := "IsSUContained",
+        comment := "tests whether group contains SU",
+    )
+);
+
+AddMethod(
+    ClassicalMethDb,
+    rec(
+        method := RECOG.IsSOContained,
+        rank := 19,
+        stamp := "IsSOContained",
+        comment := "tests whether group contains SO",
+    )
+);
 
 
 

--- a/gap/perm.gi
+++ b/gap/perm.gi
@@ -415,43 +415,118 @@ FindHomMethodsPerm.Pcgs :=
 
 # The following commands install the above methods into the database:
 
-AddMethod(FindHomDbPerm, FindHomMethodsGeneric.TrivialGroup,
-          300, "TrivialGroup",
-          "just go through generators and compare to the identity");
-AddMethod(FindHomDbPerm, FindHomMethodsPerm.ThrowAwayFixedPoints,
-          100, "ThrowAwayFixedPoints",
-          "try to find a huge amount of (possible internal) fixed points");
-AddMethod(FindHomDbPerm, FindHomMethodsGeneric.FewGensAbelian,
-          99, "FewGensAbelian",
-         "if very few generators, check IsAbelian and if yes, do KnownNilpotent");
-AddMethod(FindHomDbPerm, FindHomMethodsPerm.Pcgs,
-          97, "Pcgs",
-          "use a Pcgs to calculate a stabilizer chain" );
-AddMethod(FindHomDbPerm, FindHomMethodsPerm.MovesOnlySmallPoints,
-          95, "MovesOnlySmallPoints",
-          "calculate a stabilizer chain if only small points are moved");
-AddMethod(FindHomDbPerm, FindHomMethodsPerm.NonTransitive,
-          90, "NonTransitive",
-          "try to find non-transitivity and restrict to orbit");
-AddMethod( FindHomDbPerm, FindHomMethodsPerm.Giant,
-          80, "Giant",
-          "tries to find Sn and An in their natural actions" );
-AddMethod(FindHomDbPerm, FindHomMethodsPerm.Imprimitive,
-          70, "Imprimitive",
-          "for a imprimitive permutation group, restricts to block system");
-AddMethod(FindHomDbPerm, FindHomMethodsPerm.LargeBasePrimitive,
-          60, "LargeBasePrimitive",
-          "recognises large-base primitive permutation groups" );
-AddMethod(FindHomDbPerm, FindHomMethodsPerm.StabilizerChainPerm,
-          55, "StabilizerChainPerm",
-          Concatenation(
-              "for a permutation group using a stabilizer chain via the ",
-              "<URL Text=\"genss package\">",
-              "https://gap-packages.github.io/genss/",
-              "</URL>"
-          ));
-AddMethod(FindHomDbPerm, FindHomMethodsPerm.StabChain,
-          50, "StabChain",
-          "for a permutation group using a stabilizer chain");
+AddMethod(
+    FindHomDbPerm,
+    rec(
+        method := FindHomMethodsGeneric.TrivialGroup,
+        rank := 300,
+        stamp := "TrivialGroup",
+        comment := "just go through generators and compare to the identity",
+    )
+);
+AddMethod(
+    FindHomDbPerm,
+    rec(
+        method := FindHomMethodsPerm.ThrowAwayFixedPoints,
+        rank := 100,
+        stamp := "ThrowAwayFixedPoints",
+        comment := "try to find a huge amount of (possible internal) fixed points",
+    )
+);
+
+AddMethod(
+    FindHomDbPerm,
+    rec(
+        method := FindHomMethodsGeneric.FewGensAbelian,
+        rank := 99,
+        stamp := "FewGensAbelian",
+        comment := "if very few generators, check IsAbelian and if yes, do KnownNilpotent",
+    )
+);
+
+AddMethod(
+    FindHomDbPerm,
+    rec(
+        method := FindHomMethodsPerm.Pcgs,
+        rank := 97,
+        stamp := "Pcgs",
+        comment := "use a Pcgs to calculate a stabilizer chain",
+    )
+);
+
+AddMethod(
+    FindHomDbPerm,
+    rec(
+        method := FindHomMethodsPerm.MovesOnlySmallPoints,
+        rank := 95,
+        stamp := "MovesOnlySmallPoints",
+        comment := "calculate a stabilizer chain if only small points are moved",
+    )
+);
+
+AddMethod(
+    FindHomDbPerm,
+    rec(
+        method := FindHomMethodsPerm.NonTransitive,
+        rank := 90,
+        stamp := "NonTransitive",
+        comment := "try to find non-transitivity and restrict to orbit",
+    )
+);
+
+AddMethod(
+    FindHomDbPerm,
+    rec(
+        method := FindHomMethodsPerm.Giant,
+        rank := 80,
+        stamp := "Giant",
+        comment := "tries to find Sn and An in their natural actions",
+    )
+);
+
+AddMethod(
+    FindHomDbPerm,
+    rec(
+        method := FindHomMethodsPerm.Imprimitive,
+        rank := 70,
+        stamp := "Imprimitive",
+        comment := "for a imprimitive permutation group, restricts to block system",
+    )
+);
+
+AddMethod(
+    FindHomDbPerm,
+    rec(
+        method := FindHomMethodsPerm.LargeBasePrimitive,
+        rank := 60,
+        stamp := "LargeBasePrimitive",
+        comment := "recognises large-base primitive permutation groups",
+    )
+);
+
+AddMethod(
+    FindHomDbPerm,
+    rec(
+        method := FindHomMethodsPerm.StabilizerChainPerm,
+        rank := 55,
+        stamp := "StabilizerChainPerm",
+        comment := Concatenation(
+            "for a permutation group using a stabilizer chain via the ",
+            "<URL Text=\"genss package\">",
+            "https://gap-packages.github.io/genss/",
+            "</URL>"
+        ),
+    )
+);
+AddMethod(
+    FindHomDbPerm,
+    rec(
+        method := FindHomMethodsPerm.StabChain,
+        rank := 50,
+        stamp := "StabChain",
+        comment := "for a permutation group using a stabilizer chain",
+    )
+);
+
 
 # Note that the last one will always succeed!

--- a/gap/projective.gi
+++ b/gap/projective.gi
@@ -287,71 +287,204 @@ end;
 
 # The method installations:
 
-AddMethod( FindHomDbProjective, FindHomMethodsGeneric.TrivialGroup,
-  3000, "TrivialGroup",
-        "check if all generators are scalar multiples of the identity matrix" );
-AddMethod( FindHomDbProjective, FindHomMethodsProjective.ProjDeterminant,
-  1300, "ProjDeterminant",
-        "find homomorphism to non-zero scalars mod d-th powers" );
-AddMethod( FindHomDbProjective, FindHomMethodsGeneric.FewGensAbelian,
-  1250, "FewGensAbelian",
-     "if very few generators, check IsAbelian and if yes, do KnownNilpotent");
+AddMethod(
+    FindHomDbProjective,
+    rec(
+        method := FindHomMethodsGeneric.TrivialGroup,
+        rank := 3000,
+        stamp := "TrivialGroup",
+        comment := "check if all generators are scalar multiples of the identity matrix",
+    )
+);
+
+AddMethod(
+    FindHomDbProjective,
+    rec(
+        method := FindHomMethodsProjective.ProjDeterminant,
+        rank := 1300,
+        stamp := "ProjDeterminant",
+        comment := "find homomorphism to non-zero scalars mod d-th powers",
+    )
+);
+
+AddMethod(
+    FindHomDbProjective,
+    rec(
+        method := FindHomMethodsGeneric.FewGensAbelian,
+        rank := 1250,
+        stamp := "FewGensAbelian",
+        comment := "if very few generators, check IsAbelian and if yes, do KnownNilpotent",
+    )
+);
+
 # Note that we *can* in fact use the Matrix method here, because it
 # will do the right thing when used in projective mode:
-AddMethod( FindHomDbProjective, FindHomMethodsMatrix.ReducibleIso,
-  1200, "ReducibleIso",
-        "use MeatAxe to find a composition series, do base change" );
-AddMethod( FindHomDbProjective, FindHomMethodsProjective.NotAbsolutelyIrred,
-  1100, "NotAbsolutelyIrred",
-        "write over a bigger field with smaller degree" );
-AddMethod( FindHomDbProjective, FindHomMethodsProjective.ClassicalNatural,
-  1050, "ClassicalNatural",
-        "check whether it is a classical group in its natural representation" );
-AddMethod( FindHomDbProjective, FindHomMethodsProjective.Subfield,
-  1000, "Subfield",
-        "write over a smaller field with same degree" );
-AddMethod( FindHomDbProjective, FindHomMethodsProjective.C3C5,
-  900, "C3C5",
-        "compute a normal subgroup of derived and resolve C3 and C5" );
+AddMethod(
+    FindHomDbProjective,
+    rec(
+        method := FindHomMethodsMatrix.ReducibleIso,
+        rank := 1200,
+        stamp := "ReducibleIso",
+        comment := "use MeatAxe to find a composition series, do base change",
+    )
+);
+
+AddMethod(
+    FindHomDbProjective,
+    rec(
+        method := FindHomMethodsProjective.NotAbsolutelyIrred,
+        rank := 1100,
+        stamp := "NotAbsolutelyIrred",
+        comment := "write over a bigger field with smaller degree",
+    )
+);
+
+AddMethod(
+    FindHomDbProjective,
+    rec(
+        method := FindHomMethodsProjective.ClassicalNatural,
+        rank := 1050,
+        stamp := "ClassicalNatural",
+        comment := "check whether it is a classical group in its natural representation",
+    )
+);
+
+AddMethod(
+    FindHomDbProjective,
+    rec(
+        method := FindHomMethodsProjective.Subfield,
+        rank := 1000,
+        stamp := "Subfield",
+        comment := "write over a smaller field with same degree",
+    )
+);
+
+AddMethod(
+    FindHomDbProjective,
+    rec(
+        method := FindHomMethodsProjective.C3C5,
+        rank := 900,
+        stamp := "C3C5",
+        comment := "compute a normal subgroup of derived and resolve C3 and C5",
+    )
+);
+
 #AddMethod( FindHomDbProjective, FindHomMethodsProjective.Derived,
 #   900, "Derived",
 #        "restrict to derived subgroup" );
 # Superseded by C3C5.
-AddMethod( FindHomDbProjective, FindHomMethodsProjective.C6,
-   850, "C6",
-        "find either an (imprimitive) action or a symplectic one" );
-AddMethod( FindHomDbProjective, FindHomMethodsProjective.D247,
-   840, "D247",
-        "play games to find a normal subgroup" );
+AddMethod(
+    FindHomDbProjective,
+    rec(
+        method := FindHomMethodsProjective.C6,
+        rank := 850,
+        stamp := "C6",
+        comment := "find either an (imprimitive) action or a symplectic one",
+    )
+);
+
+AddMethod(
+    FindHomDbProjective,
+    rec(
+        method := FindHomMethodsProjective.D247,
+        rank := 840,
+        stamp := "D247",
+        comment := "play games to find a normal subgroup",
+    )
+);
+
 # We can do the following early on since it will quickly fail for
 # non-sporadic groups:
-AddMethod( FindHomDbProjective, FindHomMethodsProjective.SporadicsByOrders,
-   820, "SporadicsByOrders",
-        "generate a few random elements and compute the proj. orders" );
-AddMethod( FindHomDbProjective, FindHomMethodsProjective.AltSymBBByDegree,
-   810, "AltSymBBByDegree",
-        "try BB recognition for dim+1 and/or dim+2 if sensible" );
-AddMethod( FindHomDbProjective, FindHomMethodsProjective.TensorDecomposable,
-   800, "TensorDecomposable",
-        "find a tensor decomposition" );
-AddMethod( FindHomDbProjective, FindHomMethodsProjective.FindElmOfEvenNormal,
-   700, "FindElmOfEvenNormal",
-        "find D2, D4 or D7 by finding an element of an even normal subgroup" );
-AddMethod( FindHomDbProjective, FindHomMethodsProjective.LowIndex,
-   600, "LowIndex",
-        "find an (imprimitive) action on subspaces" );
-AddMethod( FindHomDbProjective, FindHomMethodsProjective.ComputeSimpleSocle,
-   550, "ComputeSimpleSocle",
-        "compute simple socle of almost simple group" );
-AddMethod( FindHomDbProjective, FindHomMethodsProjective.ThreeLargeElOrders,
-   500, "ThreeLargeElOrders",
-        "look at three large element orders" );
-AddMethod( FindHomDbProjective, FindHomMethodsProjective.LieTypeNonConstr,
-   400, "LieTypeNonConstr",
-        "do non-constructive recognition of Lie type groups" );
-AddMethod( FindHomDbProjective, FindHomMethodsProjective.StabilizerChainProj,
-   100, "StabilizerChainProj",
-        "last resort: compute a stabilizer chain (projectively)" );
+AddMethod(
+    FindHomDbProjective,
+    rec(
+        method := FindHomMethodsProjective.SporadicsByOrders,
+        rank := 820,
+        stamp := "SporadicsByOrders",
+        comment := "generate a few random elements and compute the proj. orders",
+    )
+);
+
+AddMethod(
+    FindHomDbProjective,
+    rec(
+        method := FindHomMethodsProjective.AltSymBBByDegree,
+        rank := 810,
+        stamp := "AltSymBBByDegree",
+        comment := "try BB recognition for dim+1 and/or dim+2 if sensible",
+    )
+);
+
+AddMethod(
+    FindHomDbProjective,
+    rec(
+        method := FindHomMethodsProjective.TensorDecomposable,
+        rank := 800,
+        stamp := "TensorDecomposable",
+        comment := "find a tensor decomposition",
+    )
+);
+
+AddMethod(
+    FindHomDbProjective,
+    rec(
+        method := FindHomMethodsProjective.FindElmOfEvenNormal,
+        rank := 700,
+        stamp := "FindElmOfEvenNormal",
+        comment := "find D2, D4 or D7 by finding an element of an even normal subgroup",
+    )
+);
+
+AddMethod(
+    FindHomDbProjective,
+    rec(
+        method := FindHomMethodsProjective.LowIndex,
+        rank := 600,
+        stamp := "LowIndex",
+        comment := "find an (imprimitive) action on subspaces",
+    )
+);
+
+AddMethod(
+    FindHomDbProjective,
+    rec(
+        method := FindHomMethodsProjective.ComputeSimpleSocle,
+        rank := 550,
+        stamp := "ComputeSimpleSocle",
+        comment := "compute simple socle of almost simple group",
+    )
+);
+
+AddMethod(
+    FindHomDbProjective,
+    rec(
+        method := FindHomMethodsProjective.ThreeLargeElOrders,
+        rank := 500,
+        stamp := "ThreeLargeElOrders",
+        comment := "look at three large element orders",
+    )
+);
+
+AddMethod(
+    FindHomDbProjective,
+    rec(
+        method := FindHomMethodsProjective.LieTypeNonConstr,
+        rank := 400,
+        stamp := "LieTypeNonConstr",
+        comment := "do non-constructive recognition of Lie type groups",
+    )
+);
+
+AddMethod(
+    FindHomDbProjective,
+    rec(
+        method := FindHomMethodsProjective.StabilizerChainProj,
+        rank := 100,
+        stamp := "StabilizerChainProj",
+        comment := "last resort: compute a stabilizer chain (projectively)",
+    )
+);
+
 
 # Old methods which are no longer used:
 


### PR DESCRIPTION
Change AddMethod to now take two arguments: the method database and a record which contains the method to be added and information about it. 

Setting the InfoClass InfoAddMethod to 1 now produces messages when AddMethod is called with unbound method.validatesInput component.

I added a few small changes to the documentation. The PR is now ready for review.

Now we can address #107 method for method.