### PR TITLE
Miscellaneous changes

### DIFF
--- a/gap/matrix/slconstr.gi
+++ b/gap/matrix/slconstr.gi
@@ -2481,15 +2481,21 @@ FindHomMethodsMatrix.NaturalSL := function(ri,G)
     fi;
 
 
+  # Try the recognition method
   n:=ri!.dimension;
   q:=Size(ri!.field);
   p:=Factors(q)[1];
   e:=LogInt(q,p);
   grpmem := GroupWithMemory(G);
-  repeat
-      data:=SLCR.SLDataStructure(grpmem,p,e,n);
-  until data <> fail;
-  genlist:=List(data.gens,x->x[1]);
+  # TODO find a reasonable number of tries
+  for i in [1 .. 10] do
+    data := SLCR.SLDataStructure(grpmem, p, e, n);
+    if data <> fail then break; fi;
+  od;
+  if data = fail then
+    return TemporaryFailure;
+  fi;
+  genlist := List(data.gens, x->x[1]);
 
   # Now clean out the memory everywhere in data:
   for i in [1..Length(data.gens)] do
@@ -2507,6 +2513,7 @@ FindHomMethodsMatrix.NaturalSL := function(ri,G)
   data.t21invtran := StripMemory(data.t21invtran);
   data.sinv := StripMemory(data.sinv);
 
+  # Return
   ri!.data:=data;
   ri!.dimension:=n;
   Setslpforelement(ri,SLPforElementFuncsMatrix.SLConstructive);

--- a/tst/working/quick/ProjSubfield3.tst
+++ b/tst/working/quick/ProjSubfield3.tst
@@ -7,4 +7,7 @@ gap> g := GroupWithGenerators(gens);;
 
 # Remark: The *4 comes from the fact that by blowing up we lose a factor
 #         of 4 in scalars, they are now in the projective group.
+gap> level := InfoLevel(InfoOrb);;
+gap> SetInfoLevel(InfoOrb, 0);;
 gap> ri := RECOG.TestGroup(g,true,Size(PGL(3,3^2)));;
+gap> SetInfoLevel(InfoOrb, level);;


### PR DESCRIPTION
General clean up.

Comments out unused code for natural SL recognition.

Adjusts the unused FindHomMethodsMatrix.NaturalSL to only try the constructive recognition method 10 times. Then returns TemporaryFailure.

Move a broken test.

Fix documentation of RecogniseGeneric.