### PR TITLE
Improve LargeBasePrimitive

### DIFF
--- a/gap/perm/largebase.gi
+++ b/gap/perm/largebase.gi
@@ -377,6 +377,11 @@ RECOG.AllJellyfish := function( G )
           s, l, params, p, n, k, r, jellyfishone, alljellyfish;
 
     N := LargestMovedPoint(G);
+    params := RECOG.NkrGetParameters( N );
+    if IsEmpty(params) then
+        return false;
+    fi;
+
     D := [ 1 .. N ];
 
     gens := ShallowCopy( GeneratorsOfGroup(G) );
@@ -401,8 +406,6 @@ RECOG.AllJellyfish := function( G )
     fi;
     s := alphaorbs[ Position(sizes,s) ]; # shortest <G>_<alpha>-orbit
     l := alphaorbs[ Position(sizes,l) ]; # longest <G>_<alpha>-orbit
-
-    params := RECOG.NkrGetParameters( N );
 
     for p in params do
         n := p[1]; k := p[2]; r := p[3];
@@ -490,14 +493,17 @@ end;
 #! is a subgroup of the product action wreath product <M>S_n \wr S_r</M>,
 #! and an overgroup of <M>(A_n) ^ r</M> where <M>S_n</M> and <M>A_n</M> act on
 #! the <M>k</M>-subsets of <M>\{1, ..., n\}</M>.
-#! This algorithm recognises large primitive groups with <M>r \cdot k > 1</M>
+#! This algorithm recognises fixed-point-free large primitive groups with
+#! <M>r \cdot k > 1</M>
 #! and <M>2 \cdot r \cdot k^2 \le n</M>.
 #!
 #! If <A>G</A> is imprimitive then the output is
 #! <K>NeverApplicable</K>. If <A>G</A> is primitive then
 #! the output is either a homomorphism into the
 #! natural imprimitive action of <A>G</A> on <M>nr</M> points with
-#! <M>r</M> blocks of size <M>n</M>, or <K>TemporaryFailure</K>.
+#! <M>r</M> blocks of size <M>n</M>,  or <K>TemporaryFailure</K>, or
+#! <K>NeverApplicable</K> if no parameters <M>n</M>, <M>k</M>, and <M>r</M> as
+#! above exist.
 #! @EndChunk
 FindHomMethodsPerm.LargeBasePrimitive :=
   function(ri,grp)
@@ -512,6 +518,8 @@ FindHomMethodsPerm.LargeBasePrimitive :=
     res := RECOG.AllJellyfish(grp);
     if res = fail then
         return TemporaryFailure;
+    elif res = false then
+        return NeverApplicable;
     fi;
     ri!.jellyfishinfo := res;
     T := res[1];
@@ -522,6 +530,8 @@ FindHomMethodsPerm.LargeBasePrimitive :=
     hom := GroupHomByFuncWithData(grp,Group(imgens),RECOG.JellyHomFunc,
                                   rec(T := T,seen := seen));
     SetHomom(ri,hom);
+
+    findgensNmeth(ri).method := FindKernelDoNothing;
 
     return Success;
   end;

--- a/gap/perm/largebase.gi
+++ b/gap/perm/largebase.gi
@@ -12,9 +12,14 @@
 ##  SPDX-License-Identifier: GPL-3.0-or-later
 ##
 ##
-##  This file provides code for recognising whether a permutation group
-##  on N points is isomorphic to G wr S_r where G is S_n acting on
-##  k-sets and N = Binomial(n,k)^r and kr > 1. It implements [LNPS06].
+##  This file provides code for recognising a subfamily of large base primitive
+##  permutation groups.  To be in that subfamily, a primitive permutation group
+##  G on N points must be permutation isomorphic to a subgroup of the product
+##  action wreath product G wr S_r, where G is S_n acting on k-sets, and hence
+##  N = Binomial(n,k)^r.
+##  For a precise description of which groups are recognised by this file
+##  confer to the documentation of the function LargeBasePrimitive.
+##  This file is based on the article [LNPS06].
 ##
 #############################################################################
 

--- a/gap/perm/largebase.gi
+++ b/gap/perm/largebase.gi
@@ -379,7 +379,7 @@ RECOG.AllJellyfish := function( G )
     N := LargestMovedPoint(G);
     params := RECOG.NkrGetParameters( N );
     if IsEmpty(params) then
-        return false;
+        return NeverApplicable;
     fi;
 
     D := [ 1 .. N ];
@@ -402,7 +402,7 @@ RECOG.AllJellyfish := function( G )
     if Length(Filtered(sizes,i->i=s)) > 1 or
        Length(Filtered(sizes,i->i=l)) > 1 then
         Info(InfoJellyfish,2,"no unique max or min sized G_alpha orbit");
-        return fail;
+        return TemporaryFailure;
     fi;
     s := alphaorbs[ Position(sizes,s) ]; # shortest <G>_<alpha>-orbit
     l := alphaorbs[ Position(sizes,l) ]; # longest <G>_<alpha>-orbit
@@ -427,7 +427,7 @@ RECOG.AllJellyfish := function( G )
     od;
 
     Info(InfoJellyfish,3,"getting jellyfish failed");
-    return fail;
+    return TemporaryFailure;
 
 end;
 
@@ -516,10 +516,8 @@ FindHomMethodsPerm.LargeBasePrimitive :=
     fi;
     RECOG.SetPseudoRandomStamp(grp,"Jellyfish");
     res := RECOG.AllJellyfish(grp);
-    if res = fail then
-        return TemporaryFailure;
-    elif res = false then
-        return NeverApplicable;
+    if res = NeverApplicable or res = TemporaryFailure then
+        return res;
     fi;
     ri!.jellyfishinfo := res;
     T := res[1];


### PR DESCRIPTION
Fixes a comment in perm/largebase.gi and improves LargeBasePrimitive.


### Improve LargeBasePrimitive

Documents explicitly that LargeBasePrimitive can not handle fixed points.

Moves the NkrGetParameters call to the front, so that LargeBasePrimitive
can exit as soon as it knows that it is not applicable.

If LargeBasePrimitive is successfull, then it creates an isomorphism. So
there is nothing to do for the kernel.