### PR TITLE
Improvements to three element orders

### DIFF
--- a/gap/projective.gi
+++ b/gap/projective.gi
@@ -461,7 +461,7 @@ AddMethod(
         method := FindHomMethodsProjective.ThreeLargeElOrders,
         rank := 500,
         stamp := "ThreeLargeElOrders",
-        comment := "look at three large element orders",
+        comment := "recognise Lie type groups and get its characteristic",
     )
 );
 

--- a/gap/projective/almostsimple.gi
+++ b/gap/projective/almostsimple.gi
@@ -735,9 +735,9 @@ end;
 #! simple but not alternating, this method takes the three
 #! largest element orders from a sample of pseudorandom elements of
 #! <A>G</A>. From these element orders, it tries to determine whether <A>G</A>
-#! is of Lie type or sporadic, and the characteristic of <A>G</A> if it is of
+#! is of Lie type and the characteristic of <A>G</A> if it is of
 #! Lie type. In the case when <A>G</A> is of Lie type of characteristic
-#! different from <M>p</M> or <A>G</A> is sporadic, the method also provides
+#! different from <M>p</M>, the method also provides
 #! a short list of the possible isomorphism types of <A>G</A>.
 #!
 #! This recognition method is based on the paper <Cite Key="KS09"/>.

--- a/gap/projective/almostsimple.gi
+++ b/gap/projective/almostsimple.gi
@@ -740,6 +740,9 @@ end;
 #! different from <M>p</M>, the method also provides
 #! a short list of the possible isomorphism types of <A>G</A>.
 #!
+#! This method assumes that its input is neither alternating nor sporadic and
+#! that <Ref Func="ComputeSimpleSocle"/> has already been called.
+#!
 #! This recognition method is based on the paper <Cite Key="KS09"/>.
 #! @EndChunk
 FindHomMethodsProjective.ThreeLargeElOrders := function(ri,G)

--- a/gap/projective/almostsimple/threeelorders.gi
+++ b/gap/projective/almostsimple/threeelorders.gi
@@ -1,8 +1,15 @@
-# RECOG.grouplist is used by RECOG.findchar and contains entries
-# of the form
+# RECOG.grouplist is used by RECOG.findchar, which uses the three largest
+# element orders to find the characteristic of its input lie type group.
+# RECOG.grouplist contains entries of the form
 #    [m1, m2, grp],
 # where m1 and m2 are the largest element orders found by sampling
-# a suitable number of random elements; and grp indicates a group:
+# a suitable number of random elements, and grp indicates a group as below.
+#
+# Note that RECOG.findchar first uses the three largest element orders to
+# handle some (or even all?) cases which are not already uniquely determined by
+# the largest two. Thus we only store the two largest element orders in
+# RECOG.grouplist.
+# grp is of the form:
 #    ["l",n,q] <-> L_n(q)
 #    ["G2",q]  <-> G_2(q)
 #    ["2G2",q] <-> G_2(q)

--- a/read.g
+++ b/read.g
@@ -49,7 +49,7 @@ ReadPackage("recog","gap/matrix/classical.gi");
 ReadPackage("recog","gap/matrix/slconstr.gi");
 ReadPackage("recog","gap/projective/c3c5.gi");
 ReadPackage("recog","gap/projective/d247.gi");
-ReadPackage("recog","gap/projective/almostsimple/twoelorders.gi");
+ReadPackage("recog","gap/projective/almostsimple/threeelorders.gi");
 ReadPackage("recog","gap/projective/almostsimple.gi");
 ReadPackage("recog","gap/projective/almostsimple/lietype.gi");
 ReadPackage("recog","gap/projective/almostsimple/hints.gi");


### PR DESCRIPTION
## Rename twoelorders.gi -> threeelorders.gi and improve its source comment.
The source comment now explains why RECOG.grouplist only stores two
largest element orders.

## Fix source comment of ThreeLargeElOrders

It claimed that ThreeLargeElOrders could also handle sporadic groups.
However, neither does the paper [KS09] which describes the algorithm
mention sporadic groups, nor does did I find anything relating to
sporadic groups in the function.

I tested this by taking matrix representation via AtlasGenerators for
M11, Co2 and J2 and then calling ComputeSimpleSocle and
ThreeLargeElOrders. ThreeLargeElOrders returned fail in all three cases.

## Improve explanatory string of ThreeLargeElOrders

Say that it recognises lie groups and computes their characteristic.
