### PR TITLE
Ensure return statements are on a line of their own

### DIFF
--- a/gap/base/recognition.gi
+++ b/gap/base/recognition.gi
@@ -1036,7 +1036,9 @@ RECOG.TestGroup := function(g,proj,size, optionlist...)
           Print("seedMT := ", seedMT, ";\n");
           Print("seedRS := ", seedRS, ";\n");
           Error("Alarm: Size not correct!\n");
-          if count = -1 then return fail; fi;
+          if count = -1 then
+              return fail;
+          fi;
       else
           #Print("Test was OK!\n");
           count := 3;   # worked!
@@ -1068,7 +1070,9 @@ RECOG.TestGroup := function(g,proj,size, optionlist...)
           fi;
           Error("Alarm: SLPforElement did not work!\n");
           
-          if count = -1 then return fail; fi;
+          if count = -1 then
+              return fail;
+          fi;
       fi;
   until count >= options.inTests;
 
@@ -1099,7 +1103,9 @@ RECOG.TestGroup := function(g,proj,size, optionlist...)
             fi;
 
             Error("Alarm: SLPforElement did not work on (possibly) non-group element!\n");
-            if count = -1 then return fail; fi;
+            if count = -1 then
+                return fail;
+            fi;
         fi;
     until count >= options.inTests;
   fi;
@@ -1180,10 +1186,14 @@ RECOG.TestRecognitionNode := function(ri,stop,recurse)
           return rec(err := err, badnode := ri);
       fi;
       ef := RECOG.TestRecognitionNode(RIFac(ri),stop,recurse);
-      if IsRecord(ef) then return ef; fi;
+      if IsRecord(ef) then
+          return ef;
+      fi;
       if RIKer(ri) <> fail then
           ek := RECOG.TestRecognitionNode(RIKer(ri),stop,recurse);
-          if IsRecord(ek) then return ek; fi;
+          if IsRecord(ek) then
+              return ek;
+          fi;
       fi;
       return rec( err := err, badnode := ri, factorkernelok := true );
   fi;

--- a/gap/generic/KnownNilpotent.gi
+++ b/gap/generic/KnownNilpotent.gi
@@ -88,7 +88,9 @@ FindHomMethodsGeneric.KnownNilpotent := function(ri,G)
       primes := Union(List(ords,o->Set(Factors(o))));
       RemoveSet(primes,1);    # in case there were identities!
   fi;
-  if Length(primes) < 2 then return NeverApplicable; fi;   # not our beer
+  if Length(primes) < 2 then
+      return NeverApplicable;   # not our beer
+  fi;
   cut := QuoInt(Length(primes),2);
   data := rec( primesfactor := primes{[1..cut]},
                primeskernel := primes{[cut+1..Length(primes)]},

--- a/gap/matrix.gi
+++ b/gap/matrix.gi
@@ -116,7 +116,9 @@ end;
 SLPforElementFuncsMatrix.DiscreteLog := function(ri,x)
   local log;
   log := LogFFE(x[1,1],ri!.generator);
-  if log = fail then return fail; fi;
+  if log = fail then
+      return fail;
+  fi;
   return StraightLineProgramNC([[1,log]],1);
 end;
 

--- a/gap/matrix/classical.gi
+++ b/gap/matrix/classical.gi
@@ -51,7 +51,9 @@ HasLBGgt5 := function( m, p, a, e )
     ppds := GcdInt(pm.ppds, m);
 
     # There are no ppds
-    if ppds = 1 then return false; fi;
+    if ppds = 1 then
+        return false;
+    fi;
 
     ## if e+1 does not divide ppds then
     ## we know that all primes dividing ppds are large
@@ -63,7 +65,9 @@ HasLBGgt5 := function( m, p, a, e )
              return false;
          fi;
          # if (e+1)^2 does not divide m, then not large
-         if not (m mod (e+1)^2) = 0 then return false; fi;
+         if not (m mod (e+1)^2) = 0 then
+             return false;
+         fi;
      fi;
 
      return true;
@@ -263,7 +267,9 @@ RECOG.RuledOutExtField := function (recognise, grp)
         recognise.isNotExt := true;
         return false;
     fi;
-    if b > bx then return fail; fi;
+    if b > bx then
+        return fail;
+    fi;
 
     if hint = "linear" then
         if not IsPrime(d)
@@ -581,11 +587,19 @@ IsPrimitivePrimeDivisor := function( b, a, p )
 
     local i;
 
-    if not IsPrimeInt(p) then return false; fi;
-    if not IsInt(b) or b <= 1 then return false; fi;
-    if not IsInt(a) or a <= 1 then return false; fi;
+    if not IsPrimeInt(p) then
+        return false;
+    fi;
+    if not IsInt(b) or b <= 1 then
+        return false;
+    fi;
+    if not IsInt(a) or a <= 1 then
+        return false;
+    fi;
 
-    if (b^a-1) mod p <> 0 then return false; fi;
+    if (b^a-1) mod p <> 0 then
+        return false;
+    fi;
     for i in [ 1 .. a-1 ] do
         if b^i-1 mod p = 0 then
             return false;
@@ -674,7 +688,9 @@ RECOG.TestRandomElement := function (recognise, grp)
               h := g^s;
               ## now order(h) is the product of all ppds dividing |g|, see
               ##  Section 6.1 page 250 of [NP99]
-              if IsOne(h) then return TemporaryFailure; fi;
+              if IsOne(h) then
+                  return TemporaryFailure;
+              fi;
               gmod := GModuleByMats([h], recognise.field);
               cf := MTX.CollectedFactors(gmod);
               if Length(cf) = 2 and cf[1][2] = cf[2][2] then
@@ -777,7 +793,9 @@ RECOG.TestRandomElement := function (recognise, grp)
                         return TemporaryFailure;
                     fi;
                 else
-                    if o1 < (q+1)/2 or o2 < (q+1)/2 then return TemporaryFailure; fi;
+                    if o1 < (q+1)/2 or o2 < (q+1)/2 then
+                        return TemporaryFailure;
+                    fi;
                 fi;
                 AddSet( recognise.plusminus, [1,1] );
             fi;
@@ -1189,8 +1207,12 @@ RECOG.IsSOContained := function( recognise, grp )
         IsQuadraticForm( recognise.QuadraticForm) and
         recognise.QuadraticFormType = "orthogonalcircle" then
         #orthogonal circle
-        if recognise.d mod 2 = 0 then return false; fi;
-        if recognise.currentgcd <> 1 then return fail; fi;
+        if recognise.d mod 2 = 0 then
+            return false;
+        fi;
+        if recognise.currentgcd <> 1 then
+            return fail;
+        fi;
         recognise.isNotExt := true;
         recognise.isSOContained := true;
         Info(InfoClassical,2,"The group contains SO^o(", recognise.d, ", ",
@@ -1201,8 +1223,12 @@ RECOG.IsSOContained := function( recognise, grp )
         IsQuadraticForm( recognise.QuadraticForm) and
         recognise.QuadraticFormType = "orthogonalplus" then
         #orthogonal plus
-        if recognise.d mod 2 <> 0 then return false; fi;
-        if recognise.currentgcd <> 2 then return fail; fi;
+        if recognise.d mod 2 <> 0 then
+            return false;
+        fi;
+        if recognise.currentgcd <> 2 then
+            return fail;
+        fi;
         recognise.isNotExt := true;
         recognise.isSOContained := true;
         Info(InfoClassical,2,"The group contains SO+(", recognise.d, ", ",
@@ -1213,8 +1239,12 @@ RECOG.IsSOContained := function( recognise, grp )
         IsQuadraticForm( recognise.QuadraticForm) and
         recognise.QuadraticFormType = "orthogonalminus" then
         # orthogonal minus
-        if recognise.d mod 2 <> 0 then return false; fi;
-        if recognise.currentgcd <> 2 then return fail; fi;
+        if recognise.d mod 2 <> 0 then
+            return false;
+        fi;
+        if recognise.currentgcd <> 2 then
+            return fail;
+        fi;
         recognise.isNotExt := true;
         recognise.isSOContained := true;
         Info(InfoClassical,2,"The group contains SO-(", recognise.d, ", ",
@@ -1272,7 +1302,9 @@ RECOG.NonGenericLinear := function( recognise, grp )
         return true;
     end;
 
-    if recognise.d > 3 then return false; fi;
+    if recognise.d > 3 then
+        return false;
+    fi;
     if recognise.d = 3 and not IsPowerOfTwo(recognise.q+1) then
         return false;
     fi;
@@ -1331,7 +1363,9 @@ RECOG.NonGenericSymplectic := function(recognise, grp)
     d := recognise.d;
     q := recognise.q;
 
-    if not IsEvenInt(recognise.d) then return false; fi;
+    if not IsEvenInt(recognise.d) then
+        return false;
+    fi;
 
     if recognise.isReducible = true then
        return false;
@@ -1343,7 +1377,9 @@ RECOG.NonGenericSymplectic := function(recognise, grp)
        return false;
     fi;
 
-    if d > 8 then  return false; fi;
+    if d > 8 then 
+        return false;
+    fi;
 
     if recognise.n <= 5 then
         return NotEnoughInformation;
@@ -1389,9 +1425,13 @@ RECOG.NonGenericSymplectic := function(recognise, grp)
         if not 4 in recognise.LB then
             return fail;
         fi;
-        if not 2 in  recognise.LS then return fail; fi;
+        if not 2 in  recognise.LS then
+            return fail;
+        fi;
     elif d = 4  and q >= 7 and IsPowerOfTwo(q+1) then
-        if not 4 in recognise.LB then return fail; fi;
+        if not 4 in recognise.LB then
+            return fail;
+        fi;
         if not HasElementsMultipleOf(recognise.orders, [4]) then
             return fail;
         fi;
@@ -1400,7 +1440,9 @@ RECOG.NonGenericSymplectic := function(recognise, grp)
         if not HasElementsMultipleOf(recognise.orders, [3,4]) then
             return fail;
         fi;
-        if not 4 in recognise.LB then return fail; fi;
+        if not 4 in recognise.LB then
+            return fail;
+        fi;
     else
         Info(InfoClassical,2,
              "NonGenericSymplectic: d and q must have been generic");
@@ -1439,7 +1481,9 @@ RECOG.NonGenericUnitary := function(recognise, grp)
     d := recognise.d;
     q := recognise.q;
 
-    if d > 6 then  return false; fi;
+    if d > 6 then 
+        return false;
+    fi;
 
     if recognise.isReducible = true then
        return false;
@@ -1450,7 +1494,9 @@ RECOG.NonGenericUnitary := function(recognise, grp)
        return false;
     fi;
 
-    if recognise.maybeFrobenius = false then return false; fi;
+    if recognise.maybeFrobenius = false then
+        return false;
+    fi;
 
     if recognise.n <= 5 then
         return NotEnoughInformation;
@@ -1474,8 +1520,12 @@ RECOG.NonGenericUnitary := function(recognise, grp)
             return fail;
         fi;
     elif d = 6 and q >= 9 then
-        if not 3 in recognise.E2 then return fail; fi;
-        if not 5 in recognise.LB then return fail; fi;
+        if not 3 in recognise.E2 then
+            return fail;
+        fi;
+        if not 5 in recognise.LB then
+            return fail;
+        fi;
     elif d = 5 and q = 4 then
         if not HasElementsMultipleOf(recognise.orders, [11,12]) then
             return fail;
@@ -1493,7 +1543,9 @@ RECOG.NonGenericUnitary := function(recognise, grp)
         if not 3 in recognise.LB then
             return fail;
         fi;
-        if not 2 in recognise.E2  then return fail; fi;
+        if not 2 in recognise.E2  then
+            return fail;
+        fi;
         f1 := Collected(Factors( q^3-1 ));
         f2 := Collected(Factors( q^2-1 ));
         # check if we have a prime at least 11
@@ -1535,7 +1587,9 @@ RECOG.NonGenericUnitary := function(recognise, grp)
             return fail;
         fi;
         if recognise.hasSpecialEle = false then
-            if not Order( recognise.g ) mod 6 = 0 then return fail; fi;
+            if not Order( recognise.g ) mod 6 = 0 then
+                return fail;
+            fi;
             if ForAny( GeneratorsOfGroup(grp),
                 h -> not IsOne(Comm(h,recognise.g^3))) then
                 Info( InfoClassical,2,
@@ -1550,7 +1604,9 @@ RECOG.NonGenericUnitary := function(recognise, grp)
             return fail;
         fi;
         if recognise.hasSpecialEle = false then
-            if not Order(recognise.g) mod 5  = 0 then return fail; fi;
+            if not Order(recognise.g) mod 5  = 0 then
+                return fail;
+            fi;
             if ForAny(GeneratorsOfGroup(grp), h -> not IsOne(Comm(h,recognise.g))) then
                 Info( InfoClassical,2,
                       "The element of order 5 is not central" );
@@ -1564,7 +1620,9 @@ RECOG.NonGenericUnitary := function(recognise, grp)
             return fail;
         fi;
         if recognise.hasSpecialEle = false then
-            if Order(recognise.g) mod 8 <> 0 then return fail; fi;
+            if Order(recognise.g) mod 8 <> 0 then
+                return fail;
+            fi;
             g := recognise.g^(Order(recognise.g)/2);
             if ForAny(GeneratorsOfGroup(grp), h -> not IsOne(Comm(h,g))) then
                 Info( InfoClassical,2,
@@ -1631,8 +1689,12 @@ RECOG.NonGenericOrthogonalPlus := function(recognise,grp)
     d := recognise.d;
     q := recognise.q;
 
-    if not d in [4,6,8,10] then return false; fi;
-    if d = 10 and q <> 2 then return false; fi;
+    if not d in [4,6,8,10] then
+        return false;
+    fi;
+    if d = 10 and q <> 2 then
+        return false;
+    fi;
 
     if recognise.isReducible = true then
        return false;
@@ -1704,8 +1766,12 @@ RECOG.NonGenericOrthogonalPlus := function(recognise,grp)
             return fail;
         fi;
     elif d = 8 and (q = 4 or q > 5) then
-        if not 6 in recognise.LB then return fail; fi;
-        if not 4 in recognise.LS then return fail; fi;
+        if not 6 in recognise.LB then
+            return fail;
+        fi;
+        if not 4 in recognise.LS then
+            return fail;
+        fi;
     elif d = 6 and q = 2 then
         if not HasElementsMultipleOf( recognise.orders, [7]) and
            not HasElementsMultipleOf( recognise.orders, [15]) then
@@ -1715,10 +1781,16 @@ RECOG.NonGenericOrthogonalPlus := function(recognise,grp)
         if not HasElementsMultipleOf( recognise.orders, [5])  then
             return fail;
         fi;
-        if not 13 in recognise.orders then return fail; fi;
+        if not 13 in recognise.orders then
+            return fail;
+        fi;
     elif d = 6 and q >= 4 then
-        if not 4 in recognise.LB then return fail; fi;
-        if not 3 in recognise.E2 then return fail; fi;
+        if not 4 in recognise.LB then
+            return fail;
+        fi;
+        if not 3 in recognise.E2 then
+            return fail;
+        fi;
     elif d = 4 and (q = 8 or q >= 11) then
         if recognise.needPlusMinus = false then
             recognise.needPlusMinus := true;
@@ -1850,9 +1922,15 @@ RECOG.NonGenericOrthogonalMinus := function(recognise, grp)
     d := recognise.d;
     q := recognise.q;
 
-    if not d in [4,6,8] then return false; fi;
-    if d = 8 and q <> 2 then return false; fi;
-    if d = 6 and q > 3 then return false; fi;
+    if not d in [4,6,8] then
+        return false;
+    fi;
+    if d = 8 and q <> 2 then
+        return false;
+    fi;
+    if d = 6 and q > 3 then
+        return false;
+    fi;
 
     if recognise.isReducible = true then
        return false;
@@ -1901,7 +1979,9 @@ RECOG.NonGenericOrthogonalMinus := function(recognise, grp)
          fi;
     elif d = 4 and q >=  4 then
         ppd := IsPpdElement( recognise.field, recognise.cpol, d, q, 1 );
-        if ppd = false or ppd[1] <> 4  or ppd[2] <> true then return fail; fi;
+        if ppd = false or ppd[1] <> 4  or ppd[2] <> true then
+            return fail;
+        fi;
         # found a ppd( 4, q; 4)-element
         g := recognise.g;
         for h in GeneratorsOfGroup(grp) do
@@ -1932,8 +2012,12 @@ RECOG.NonGenericOrthogonalCircle := function( recognise, grp )
 
     isParForm := f -> IsSesquilinearForm(f) and IsParabolicForm(f);
 
-    if not IsOddInt(recognise.d) then return false; fi;
-    if not IsOddInt(recognise.q) then return false; fi;
+    if not IsOddInt(recognise.d) then
+        return false;
+    fi;
+    if not IsOddInt(recognise.q) then
+        return false;
+    fi;
 
     CheckFlag := function( )
         if recognise.isReducible = "unknown" then
@@ -1986,7 +2070,9 @@ RECOG.NonGenericOrthogonalCircle := function( recognise, grp )
             return fail;
         fi;
     elif d = 5 and q >= 5 then
-        if not 4 in recognise.LE then return fail; fi;
+        if not 4 in recognise.LE then
+            return fail;
+        fi;
     elif d = 3 and q = 3 then
         if not HasElementsMultipleOf( recognise.orders, [3])  then
             return fail;
@@ -2004,7 +2090,9 @@ RECOG.NonGenericOrthogonalCircle := function( recognise, grp )
             return fail;
         fi;
         if recognise.hasSpecialEle = false then
-            if not Order(recognise.g) in [4,8] then return fail; fi;
+            if not Order(recognise.g) in [4,8] then
+                return fail;
+            fi;
             g := recognise.g^2;
             if ForAny(GeneratorsOfGroup(grp), h -> not IsOne(Comm(h,g))) then
                recognise.hasSpecialEle := true;
@@ -2042,7 +2130,9 @@ RECOG.NonGenericOrthogonalCircle := function( recognise, grp )
         fi;
     elif d = 3 and ((q+1) mod 3 <> 0 or not IsPowerOfTwo((q+1)/3)) and
                    not IsPowerOfTwo(q+1) then
-        if not 2 in recognise.LB then return fail; fi;
+        if not 2 in recognise.LB then
+            return fail;
+        fi;
         if not ForAny(recognise.orders, i -> i > 2 and (q-1) mod i = 0) then
             return fail;
         fi;

--- a/gap/matrix/matimpr.gi
+++ b/gap/matrix/matimpr.gi
@@ -81,7 +81,9 @@ RECOG.IndexMaxSub := function( hm, grp, d )
         Enumerate(orb,4*d);
         if not IsClosed(orb) then
             Info(InfoRecog,2,"Did not find nice orbit.");
-            if lastsub = fail then return fail; fi;
+            if lastsub = fail then
+                return fail;
+            fi;
             return rec( orb := lastorb,
                         hom := OrbActionHomomorphism(grp,lastorb) );
         fi;
@@ -137,11 +139,17 @@ RECOG.SmallHomomorphicImageProjectiveGroup := function ( grp )
           hm := GModuleByMats(gens,fld);
           if not MTX.IsIrreducible(hm) then
               res := RECOG.IndexMaxSub( hm, grp, d );
-              if res <> fail then return [res, gens]; fi;
+              if res <> fail then
+                  return [res, gens];
+              fi;
               if i < LogInt(d,2) then
                   res := findred(gens);
-                  if res = false then return false; fi;
-                  if res <> fail then return res; fi;
+                  if res = false then
+                      return false;
+                  fi;
+                  if res <> fail then
+                      return res;
+                  fi;
               fi;
           fi;
       od;

--- a/gap/matrix/ppd.gi
+++ b/gap/matrix/ppd.gi
@@ -30,7 +30,9 @@ PrimitivePrimeDivisors := function(d, q)
 
     local ddivs, c, a, ppds, noppds;
 
-    if d < 1 or q < 2 then return fail; fi;
+    if d < 1 or q < 2 then
+        return fail;
+    fi;
     if d = 1 then
         return rec( ppds := q-1, noppds := 1 );
     fi;

--- a/gap/matrix/slconstr.gi
+++ b/gap/matrix/slconstr.gi
@@ -1252,7 +1252,9 @@ return fail;
         smat[1,1] := Z(q)^(-2* exp);
         mat := mat * smat;
      fi;
-     if not (Determinant(mat) = Z(q)^0) then return fail; fi;
+     if not IsOne(Determinant(mat)) then
+         return fail;
+     fi;
      if d > 2 then
         #****error here
         slp := SLCR.SLSLP(data, mat^(-1), d-1);

--- a/gap/perm/largebase.gi
+++ b/gap/perm/largebase.gi
@@ -104,7 +104,9 @@ RECOG.NkrTraceSchreierTree := function( beta, sv )
 
     local o, h;
 
-    if sv[beta] = false then return fail; fi;
+    if sv[beta] = false then
+        return fail;
+    fi;
 
     o := One(sv[beta]);
     h := One(sv[beta]);
@@ -254,7 +256,9 @@ RECOG.GetAllJellyfish := function( jellyfish, idjf, G, n, k, r )
     HaveSeen := function( jellyfish )
         local s;
         for s in seen do
-            if IsSubset(jellyfish,s) then return true;fi;
+            if IsSubset(jellyfish,s) then
+                return true;
+            fi;
         od;
         return false;
     end;
@@ -293,7 +297,9 @@ RECOG.GetAllJellyfish := function( jellyfish, idjf, G, n, k, r )
         top := top - 1;
     od;
 
-    if Length( seen ) <> n*r then return fail; fi;
+    if Length( seen ) <> n*r then
+        return fail;
+    fi;
 
     return [ T, seen ];
 
@@ -315,7 +321,9 @@ RECOG.OtherGetAllJellyfish:=function ( jellyfish, idjf, G, n, k, r )
     HaveSeen := function( jellyfish )
         local s;
         for s in seen do
-            if IsSubset(jellyfish,s) then return true;fi;
+            if IsSubset(jellyfish,s) then
+                return true;
+            fi;
         od;
         return false;
     end;
@@ -348,7 +356,9 @@ RECOG.OtherGetAllJellyfish:=function ( jellyfish, idjf, G, n, k, r )
         od;
     od;
 
-    if Length( seen ) <> n*r then return fail; fi;
+    if Length( seen ) <> n*r then
+        return fail;
+    fi;
 
     return [ T, seen ];
 

--- a/gap/projective.gi
+++ b/gap/projective.gi
@@ -149,7 +149,9 @@ end;
 RECOG.HomProjDet := function(data,m)
   local x;
   x := LogFFE(DeterminantMat(m),data.z);
-  if x = fail then return fail; fi;
+  if x = fail then
+      return fail;
+  fi;
   return data.c ^ (x mod data.gcd);
 end;
 
@@ -166,10 +168,14 @@ FindHomMethodsProjective.ProjDeterminant := function(ri,G)
   d := ri!.dimension;
   q := Size(f);
   gcd := GcdInt(q-1,d);
-  if gcd = 1 then return NeverApplicable; fi;
+  if gcd = 1 then
+      return NeverApplicable;
+  fi;
   z := Z(q);
   detsadd := List(GeneratorsOfGroup(G),x->LogFFE(DeterminantMat(x),z) mod gcd);
-  if IsZero(detsadd) then return NeverApplicable; fi;
+  if IsZero(detsadd) then
+      return NeverApplicable;
+  fi;
   Info(InfoRecog,2,"ProjDeterminant: found non-trivial homomorphism.");
   c := PermList(Concatenation([2..gcd],[1]));
   newgens := List(detsadd,x->c^x);

--- a/gap/projective/AnSnOnFDPM.gi
+++ b/gap/projective/AnSnOnFDPM.gi
@@ -1592,6 +1592,8 @@ RECOG.RecogniseFDPM := function(group, field, eps)
   cob := uvs[2];
   ConvertToMatrixRep(cob);
   cobi := cob^-1;
-  if cobi = fail then return fail; fi;
+  if cobi = fail then
+    return fail;
+  fi;
   return rec( cob := cob, cobi := cobi, fdpm := fdpm );
 end;

--- a/gap/projective/almostsimple.gi
+++ b/gap/projective/almostsimple.gi
@@ -645,7 +645,9 @@ RECOG.MakePSL2Hint := function( name, G )
   p := Characteristic(f);
   d := DimensionOfMatrixGroup(G);
   defchar := Factors(name[3])[1];
-  if p = defchar then return fail; fi;
+  if p = defchar then
+      return fail;
+  fi;
   Info(InfoRecog,2,"Making hint for group ",name,"...");
   # we are in cross characteristic.
   # to be made better...
@@ -1422,12 +1424,16 @@ FindHomMethodsProjective.SporadicsByOrders := function(ri,G)
   for i in [1..Length(l)] do
       Info(InfoRecog,2,"Trying hint for ",RECOG.SporadicsNames[l[i]],"...");
       res := LookupHintForSimple(ri,G,RECOG.SporadicsNames[l[i]]);
-      if res = true then return Success; fi;
+      if res = true then
+          return Success;
+      fi;
       if IsBound(RECOG.SporadicsWorkers[l[i]]) then
           Info(InfoRecog,2,"Calling its installed worker...");
           res := RECOG.SporadicsWorkers[l[1]](RECOG.SporadicsNames[l[i]],
                                         RECOG.SporadicsSizes[l[i]],ri,G);
-          if res = true then return Success; fi;
+          if res = true then
+              return Success;
+          fi;
       fi;
       Info(InfoRecog,2,"This did not work.");
   od;

--- a/gap/projective/c6.gi
+++ b/gap/projective/c6.gi
@@ -688,7 +688,9 @@ RECOG.New2RecogniseC6 := function(grp)
 
     ## first find a non-central element of the <r>-core of <grp>
     b := RECOG.BlindDescent(r,n,grp,100);
-    if b = fail then return TemporaryFailure; fi;
+    if b = fail then
+        return TemporaryFailure;
+    fi;
     Info(InfoRecog,3,"Finished blind descent");
 
     u := b[1];

--- a/gap/projective/classicalnatural.gi
+++ b/gap/projective/classicalnatural.gi
@@ -460,7 +460,9 @@ RECOG.FindStdGensUsingBSGS := function(g,stdgens,projective,large)
   l := List(stdgens,x->SiftGroupElementSLP(S,x));
   gens := EmptyPlist(Length(stdgens));
   for i in [1..Length(stdgens)] do
-      if not l[i].isone then return fail; fi;
+      if not l[i].isone then
+          return fail;
+      fi;
       Add(gens,ResultOfStraightLineProgram(l[i].slp,strong));
   od;
   return SLPOfElms(gens);
@@ -1192,7 +1194,9 @@ RECOG.RecogniseSL2NaturalOddCharUsingBSGS := function(g,f)
   q := Size(f);
   std := RECOG.MakeSL_StdGens(p,ext,2,2);
   slp := RECOG.FindStdGensUsingBSGS(g,std.all,false,true);
-  if slp = fail then return fail; fi;
+  if slp = fail then
+      return fail;
+  fi;
   res := rec( g := g, one := One(f), One := One(g), f := f, q := q,
               p := p, ext := ext, d := 2, bas := IdentityMat(2,f),
               basi := IdentityMat(2,f) );
@@ -1437,7 +1441,9 @@ RECOG.GuessProjSL2ElmOrder := function(x,f)
   fi;
   if p > 2 then
       y := x^p;
-      if IsOneProjective(y) then return p; fi;
+      if IsOneProjective(y) then
+          return p;
+      fi;
   fi;
   if IsOneProjective(x^(q-1)) then
       facts := Collected(FactInt(q-1:cheap)[1]);
@@ -1474,24 +1480,34 @@ RECOG.IsThisSL2Natural := function(gens,f)
   CheckElm := function(x)
       local o;
       o := RECOG.GuessProjSL2ElmOrder(x,f);
-      if o in [1,2] then return false; fi;
+      if o in [1,2] then
+          return false;
+      fi;
       if o > 5 then
           if notA5 = false then Info(InfoRecog,4,"SL2: Group is not A5"); fi;
           notA5 := true;
-          if seenqp1 and seenqm1 then return true; fi;
+          if seenqp1 and seenqm1 then
+              return true;
+          fi;
       fi;
-      if o = p or o <= 5 then return false; fi;
+      if o = p or o <= 5 then
+          return false;
+      fi;
       if (q+1) mod o = 0 then
           if not seenqp1 then
               Info(InfoRecog,4,"SL2: Found element of order dividing q+1.");
               seenqp1 := true;
-              if seenqm1 and notA5 then return true; fi;
+              if seenqm1 and notA5 then
+                  return true;
+              fi;
           fi;
       else
           if not seenqm1 then
               Info(InfoRecog,4,"SL2: Found element of order dividing q-1.");
               seenqm1 := true;
-              if seenqp1 and notA5 then return true; fi;
+              if seenqp1 and notA5 then
+                  return true;
+              fi;
           fi;
       fi;
       return false;
@@ -1520,7 +1536,9 @@ RECOG.IsThisSL2Natural := function(gens,f)
   notA5 := false;
 
   for i in [1..Length(gens)] do
-      if CheckElm(gens[i]) then return true; fi;
+      if CheckElm(gens[i]) then
+          return true;
+      fi;
   od;
   CheckElm(gens[1]*gens[2]);
   if Length(gens) >= 3 then
@@ -1536,7 +1554,9 @@ RECOG.IsThisSL2Natural := function(gens,f)
       for i in [1..l-1] do
           for j in [i+1..l] do
               x := Comm(gens[i],gens[j]);
-              if CheckElm(x) then return true; fi;
+              if CheckElm(x) then
+                  return true;
+              fi;
               Add(coms,x);
           od;
       od;
@@ -1546,7 +1566,9 @@ RECOG.IsThisSL2Natural := function(gens,f)
           a := RECOG.RandomSubproduct(gens,rec());
           b := RECOG.RandomSubproduct(gens,rec());
           x := Comm(a,b);
-          if CheckElm(x) then return true; fi;
+          if CheckElm(x) then
+              return true;
+          fi;
           Add(coms,x);
       od;
   fi;
@@ -1557,7 +1579,9 @@ RECOG.IsThisSL2Natural := function(gens,f)
   Info(InfoRecog,4,"SL2: Computing normal closure...");
   clos := FastNormalClosure(gens,coms,5);
   for i in [Length(coms)+1..Length(clos)] do
-      if CheckElm(clos[i]) then return true; fi;
+      if CheckElm(clos[i]) then
+          return true;
+      fi;
   od;
   if ForAll(clos{[Length(coms)+1..Length(clos)]}, RECOG.IsScalarMat) then
       Info(InfoRecog,4,"SL2: Group is soluble, derived subgroup central");

--- a/gap/projective/d247.gi
+++ b/gap/projective/d247.gi
@@ -152,7 +152,9 @@ RECOG.DirectFactorsFinder := function(gens,facgens,k,eq)
   fi;
 
   pgens := List(pgens,PermList);
-  if fail in pgens then return fail; fi;
+  if fail in pgens then
+    return fail;
+  fi;
   return [o,pgens];
 end;
 
@@ -401,7 +403,9 @@ FindHomMethodsProjective.D247 := function(ri,G)
   for i in [1..9] do
       if InfoLevel(InfoRecog) >= 2 then Print(".\c"); fi;
       res := CheckNormalClosure(x);
-      if res in [true,false] then return res; fi;
+      if res in [true,false] then
+          return res;
+      fi;
       x := RECOG.InvolutionJumper(ri!.pr,RECOG.ProjectiveOrder,x,100,true);
       if x = fail then
           if InfoLevel(InfoRecog) >= 2 then Print("\n"); fi;
@@ -410,7 +414,9 @@ FindHomMethodsProjective.D247 := function(ri,G)
       fi;
   od;
   res := CheckNormalClosure(x);
-  if res in [true,false] then return res; fi;
+  if res in [true,false] then
+      return res;
+  fi;
   if InfoLevel(InfoRecog) >= 2 then Print("\n"); fi;
   Info(InfoRecog,2,"D247: Did not find normal subgroup, giving up.");
   return TemporaryFailure;

--- a/gap/projective/findnormal.gi
+++ b/gap/projective/findnormal.gi
@@ -447,9 +447,13 @@ InstallMethod( FindElmOfEvenNormalSubgroup, "for a group object and a record",
 
     # Some helper function:
     AddList := function(l,el)
-      if opt.IsOne(el) then return false; fi;
+      if opt.IsOne(el) then
+          return false;
+      fi;
       for i in [1..Length(l)] do
-          if opt.Eq(l[i],el) then return false; fi;
+          if opt.Eq(l[i],el) then
+              return false;
+          fi;
       od;
       Add(l,el);
       return true;
@@ -599,7 +603,9 @@ InstallMethod( FindElmOfEvenNormalSubgroup, "for a group object and a record",
                   for y in iter do
                       if not opt.IsOne(y) then
                           UseElement(y);
-                          if blindr.isknownproper then return blindr; fi;
+                          if blindr.isknownproper then
+                              return blindr;
+                          fi;
                       fi;
                   od;
                   blindr.msg :=
@@ -615,7 +621,9 @@ InstallMethod( FindElmOfEvenNormalSubgroup, "for a group object and a record",
                       fi;
                       if not opt.IsOne(y) then
                           UseElement(y);
-                          if blindr.isknownproper then return blindr; fi;
+                          if blindr.isknownproper then
+                              return blindr;
+                          fi;
                       fi;
                   od;
                   blindr.msg :=
@@ -766,7 +774,9 @@ FindHomMethodsProjective.FindElmOfEvenNormal := function(ri,G)
               fi;
               res := RECOG.SortOutReducibleSecondNormalSubgroup(
                                       ri,G,rr.Ngens,mm);
-              if res = true then return Success; fi;
+              if res = true then
+                  return Success;
+              fi;
               r := rr;
           until count >= 2;
       fi;

--- a/gap/projective/tensor.gi
+++ b/gap/projective/tensor.gi
@@ -389,7 +389,9 @@ end;
 RECOG.HomTensorFactor := function(data,m)
   local k;
   k := RECOG.IsKroneckerProduct(m,data.blocksize);
-  if k[1] <> true then return fail; fi;
+  if k[1] <> true then
+      return fail;
+  fi;
   return k[3];
 end;
 

--- a/gap/tools.gi
+++ b/gap/tools.gi
@@ -82,15 +82,23 @@ Unbind(RECOG.InitBinomialTab);
 RECOG.CheckFingerPrint := function(fp,orders)
     local count,i;
     if IsBound(fp.notorders) then
-        if ForAny(orders,o->o in fp.notorders) then return 0; fi;
+        if ForAny(orders,o->o in fp.notorders) then
+            return 0;
+        fi;
     fi;
     if IsBound(fp.exponent) then
-        if ForAny(orders,o->fp.exponent mod o <> 0) then return 0; fi;
+        if ForAny(orders,o->fp.exponent mod o <> 0) then
+            return 0;
+        fi;
     elif IsBound(fp.size) then
-        if ForAny(orders,o->fp.size mod o <> 0) then return 0; fi;
+        if ForAny(orders,o->fp.size mod o <> 0) then
+            return 0;
+        fi;
     fi;
     if IsBound(fp.allorders) then
-        if ForAny(orders,o->not o in fp.allorders) then return 0; fi;
+        if ForAny(orders,o->not o in fp.allorders) then
+            return 0;
+        fi;
     fi;
     count := Number(orders,o->o in fp.freqorders);
     return RECOG.BinomialTab[Length(orders)][count+1]/2^(Length(orders));


### PR DESCRIPTION
This allows us to see in code coverage reports which of those returns are actually being taken.