### PR TITLE
Enable TestGroupOptions.tryNonGroupElements

### DIFF
--- a/gap/base/recognition.gi
+++ b/gap/base/recognition.gi
@@ -991,7 +991,7 @@ RECOG.TestGroupOptions := rec(
 
       # if the following is set to true, then we test what happens if  SLPforElement
       # is called with elements outside the group
-      tryNonGroupElements := false
+      tryNonGroupElements := true,
   );
 
 


### PR DESCRIPTION
This checks whether recog can correctly recognise, that a given input
does not lie in the recognised group.


-
Lets see whether the tests pass.
