### PR TITLE
Tweak GitHub Actions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -6,9 +6,12 @@ on:
   - pull_request
 
 jobs:
+  # The CI test job
   test:
     name: ${{ matrix.gap-branch }} - ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    # Don't run this twice on PRs for branches pushed to the same repository
+    if: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) }}
     strategy:
       fail-fast: false
       matrix:
@@ -22,25 +25,24 @@ jobs:
       - uses: actions/checkout@v2
       - uses: gap-actions/setup-gap-for-packages@v1
         with:
-          GAP_PKGS_TO_CLONE: "AutoDoc"
           GAPBRANCH: ${{ matrix.gap-branch }}
-      - uses: gap-actions/compile-documentation-for-packages@v1
       - uses: gap-actions/run-test-for-packages@v1
 
+  # The documentation job
   manual:
     name: Build manuals
     runs-on: ubuntu-latest
+    # Don't run this twice on PRs for branches pushed to the same repository
+    if: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) }}
 
     steps:
       - uses: actions/checkout@v2
       - uses: gap-actions/setup-gap-for-packages@v1
-        with:
-          GAP_PKGS_TO_CLONE: "AutoDoc"
       - uses: gap-actions/compile-documentation-for-packages@v1
         with:
           use-latex: 'true'
       - name: "Upload documentation"
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         with:
           name: manual
           path: ./doc/manual.pdf


### PR DESCRIPTION
Just a couple of small changes to bring this into line with the example package.

Also, I don't think there's a need to compile the documentation on every test job, so I've removed that. It should save some seconds.

(I also don't think it's necessary to explicitly clone AutoDoc).