### PR TITLE
Remove convention sections

### DIFF
--- a/doc/intro.xml
+++ b/doc/intro.xml
@@ -21,7 +21,7 @@ The setup is described in <Cite Key="NS06"/>. <P/>
 The framework allows to build composition trees and handles the builtup
 and usage of these trees in a generic way. It also contains a
 method selection (described in Chapter <Ref Chap="methsel"/>) that allows
-install recognition methods in a convenient way and that automatically
+to install recognition methods in a convenient way and that automatically
 tries to try the different available methods in a sensible order.
 </Section>
 

--- a/doc/intro.xml
+++ b/doc/intro.xml
@@ -14,8 +14,8 @@ behind the package.
 This package is about group recognition. It provides a generic
 framework to implement methods of group recognition, regardless of
 what computational representation is used. This means, that the code
-in this package is useful at least for permutation groups, matrix
-groups and projective groups.
+in this package is useful at least for permutation groups, and matrix
+groups and projective groups over finite fields.
 The setup is described in <Cite Key="NS06"/>. <P/>
 
 The framework allows to build composition trees and handles the builtup

--- a/doc/recognition.xml
+++ b/doc/recognition.xml
@@ -709,29 +709,6 @@ of the nice generators of the current node.
 
 </Section>
 
-<Section Label="convperm">
-    <Heading>Conventions for the recognition of permutation groups</Heading>
-
-No conventions so far.
-</Section>
-
-<Section Label="convmat">
-    <Heading>Conventions for the recognition of matrix groups</Heading>
-
-We are considering only the case of matrix groups over finite fields.<P/>
-
-No conventions so far.
-</Section>
-
-<Section Label="convproj">
-    <Heading>Conventions for the recognition of projective groups</Heading>
-
-We are considering only the case of projective groups over finite fields.<P/>
-
-No conventions so far.
-</Section>
-
-
 <!-- ############################################################ -->
 
 </Chapter>

--- a/gap/base/recognition.gd
+++ b/gap/base/recognition.gd
@@ -498,7 +498,7 @@ DeclareSynonym("RecognizePermGroup", RecognisePermGroup);
 ## <Func Name="RecognizeMatrixGroup" Arg="H"/>
 ## <Returns><K>fail</K> for failure or a recognition info record.</Returns>
 ## <Description>
-## <A>H</A> must be a &GAP; matrix group object. This function calls
+## <A>H</A> must be a &GAP; matrix group object over a finite field. This function calls
 ## <Ref Func="RecogniseGeneric"/> with the method database used for
 ## matrix groups, which is stored in the global variable
 ## <Ref Var="FindHomDbMatrix"/>, and no prior knowledge.
@@ -514,7 +514,7 @@ DeclareSynonym("RecognizeMatrixGroup", RecogniseMatrixGroup);
 ## <Func Name="RecognizeProjectiveGroup" Arg="H"/>
 ## <Returns><K>fail</K> for failure or a recognition info record.</Returns>
 ## <Description>
-## <A>H</A> must be a &GAP; matrix group object. Since as of now no
+## <A>H</A> must be a &GAP; matrix group object over a finite field. Since as of now no
 ## actual projective groups are implemented in the &GAP; library we use
 ## matrix groups instead. The recognition will however view the group as
 ## the projective group, i.e. the matrix group modulo its scalar


### PR DESCRIPTION
- Remove "Conventions" sections from the docs
  - We don't have any conventions. That we only handle finite fields should
    rather go into the introduction.
- Fix a typo
- Document that we can only handle finite fields
