### PR TITLE
Add testslow.g and testveryslow.g

### DIFF
--- a/tst/testslow.g
+++ b/tst/testslow.g
@@ -1,0 +1,3 @@
+LoadPackage("recog");
+TestDirectory(DirectoriesPackageLibrary("recog", "tst/working/slow"), rec(exitGAP := true));
+FORCE_QUIT_GAP(1);

--- a/tst/testveryslow.g
+++ b/tst/testveryslow.g
@@ -1,0 +1,3 @@
+LoadPackage("recog");
+TestDirectory(DirectoriesPackageLibrary("recog", "tst/working/veryslow"), rec(exitGAP := true));
+FORCE_QUIT_GAP(1);

--- a/tst/working/veryslow/MatFDPM.tst
+++ b/tst/working/veryslow/MatFDPM.tst
@@ -1,4 +1,4 @@
-# FDPM = fully deleted permutation
+# FDPM = fully deleted permutation module
 
 # Alternating:
 gap> deg := Random(10,88);;


### PR DESCRIPTION
Add testslow.g and testveryslow.g. I'd like to have these so that I can run the three test suites in parallel.

Currently `TestRecogGL(6,27);;` fails. This should we fixed once we have
mandarins though.

Also adds a comment.