### PR TITLE
Improve and unify names (2)

### DIFF
--- a/doc/howtowritearecogmethod.autodoc
+++ b/doc/howtowritearecogmethod.autodoc
@@ -163,8 +163,8 @@ FindHomMethodsMatrix.BlockLowerTriangular := function(ri, G)
   # first.
 
   # Give hint to image
-  forfactor(ri).blocks := ri!.blocks;
-  Add(forfactor(ri).hints,
+  InitialDataForImageRecogNode(ri).blocks := ri!.blocks;
+  Add(InitialDataForImageRecogNode(ri).hints,
       rec( method := FindHomMethodsMatrix.BlockDiagonal,
            rank := 2000,
            stamp := "BlockDiagonal" ) );
@@ -174,11 +174,11 @@ FindHomMethodsMatrix.BlockLowerTriangular := function(ri, G)
   findgensNmeth(ri).args := [];
 
   # Give hint to kernel N
-  Add(forkernel(ri).hints,
+  Add(InitialDataForKernelRecogNode(ri).hints,
       rec( method := FindHomMethodsMatrix.LowerLeftPGroup,
            rank := 2000,
            stamp := “LowerLeftPGroup" ));
-  forkernel(ri).blocks := ri!.blocks;
+  InitialDataForKernelRecogNode(ri).blocks := ri!.blocks;
 
   # This function always succeeds, because it is only
   # called for inputs for which it is known to apply.

--- a/doc/recognition.xml
+++ b/doc/recognition.xml
@@ -218,12 +218,12 @@ The following attributes are defined for recognition nodes:
 <#Include Label="pregensfac">
 <#Include Label="ImageRecogNode">
 <#Include Label="KernelRecogNode">
-<#Include Label="RIParent">
+<#Include Label="ParentRecogNode">
 <#Include Label="fhmethsel">
 <#Include Label="slpforelement">
 <#Include Label="SLPforElement">
 <#Include Label="StdPresentation">
-<#Include Label="methodsforfactor">
+<#Include Label="methodsforimage">
 
 <ManSection>
 <Attr Name="validatehomominput" Arg="ri, x"/>
@@ -402,7 +402,7 @@ recognised by the current recognition node to the image or
 kernel of the found homomorphism:
 
 <ManSection>
-<Attr Name="forkernel" Arg="ri"/>
+<Attr Name="InitialDataForKernelRecogNode" Arg="ri"/>
 <Description>
     This attribute is initialised to a record with only the component
     <C>hints</C> bound to an empty list at the beginning of the
@@ -424,7 +424,7 @@ kernel of the found homomorphism:
 </ManSection>
 
 <ManSection>
-<Attr Name="forfactor" Arg="ri"/>
+<Attr Name="InitialDataForImageRecogNode" Arg="ri"/>
 <Description>
     This attribute is initialised to a record with only the component
     <C>hints</C> bound to an empty list at the beginning of the
@@ -627,7 +627,7 @@ A successful find homomorphism method has the following duties:
     group in the attribute <Ref Attr="Homom"/>. Note that if your homomorphism
     changes the representation (for example going from matrix groups to
     permutation groups), you will have to set the attribute
-    <Ref Attr="methodsforfactor"/> accordingly. Also,
+    <Ref Attr="methodsforimage"/> accordingly. Also,
     <Ref Attr="ValidateHomomInput"/> may be set to a function which returns
     <K>false</K> for values which may cause <Ref Attr="Homom"/> to
     produce the wrong answer, or error.
@@ -652,7 +652,7 @@ A successful find homomorphism method has the following duties:
 <Mark>additional information</Mark>
 <Item>
     A find homomorphism method may store any data into the attributes
-    <Ref Attr="forkernel"/> and <Ref Attr="forfactor"/>, which both are
+    <Ref Attr="InitialDataForKernelRecogNode"/> and <Ref Attr="InitialDataForImageRecogNode"/>, which both are
     records. Components in these
     record that are bound during the recognition will be copied into
     the recognition node of the kernel and image respectively

--- a/doc/renaming.xml
+++ b/doc/renaming.xml
@@ -1,8 +1,6 @@
 <Chapter Label="Renaming">
 <Heading>Renaming</Heading>
 
-<#Include SYSTEM "renaming_index.xml">
-
 Many of the names in the recog package were found
 to be unintuitive or inconsistent with other names.
 For these reasons the names were changed to be more descriptive

--- a/doc/renaming_index.xml
+++ b/doc/renaming_index.xml
@@ -1,4 +1,0 @@
-<Index Key="RecognitionInfoFamily"><C>RecognitionInfoFamily</C></Index>
-<Index Key="IsRecognitionInfo"><C>IsRecognitionInfo</C></Index>
-<Index Key="RIFac"><C>RIFac</C></Index>
-<Index Key="RIKer"><C>RIKer</C></Index>

--- a/doc/renaming_table.xml
+++ b/doc/renaming_table.xml
@@ -1,5 +1,5 @@
 <Table Align="|l|l|">
-<Caption> Renaming</Caption>
+<Caption>Renaming</Caption>
 <HorLine/>
 <Row>
 	<Item> <E>Old Name</E> </Item>
@@ -26,4 +26,33 @@
 	<Item> <Ref Attr="KernelRecogNode"/> </Item>
 </Row>
 <HorLine/>
+<Row>
+	<Item> <C>RIParent</C> </Item>
+	<Item> <Ref Attr="ParentRecogNode"/> </Item>
+</Row>
+<HorLine/>
+<Row>
+	<Item> <C>methodsforfactor</C> </Item>
+	<Item> <Ref Attr="methodsforimage"/> </Item>
+</Row>
+<HorLine/>
+<Row>
+	<Item> <C>forfactor</C> </Item>
+	<Item> <Ref Attr="InitialDataForImageRecogNode"/> </Item>
+</Row>
+<HorLine/>
+<Row>
+	<Item> <C>forkernel</C> </Item>
+	<Item> <Ref Attr="InitialDataForKernelRecogNode"/> </Item>
+</Row>
+<HorLine/>
 </Table>
+
+<Index Key="RecognitionInfoFamily"><C>RecognitionInfoFamily</C></Index>
+<Index Key="IsRecognitionInfo"><C>IsRecognitionInfo</C></Index>
+<Index Key="RIFac"><C>RIFac</C></Index>
+<Index Key="RIKer"><C>RIKer</C></Index>
+<Index Key="RIParent"><C>RIParent</C></Index>
+<Index Key="methodsforfactor"><C>methodsforfactor</C></Index>
+<Index Key="forfactor"><C>forfactor</C></Index>
+<Index Key="forkernel"><C>forkernel</C></Index>

--- a/gap/base/recognition.gd
+++ b/gap/base/recognition.gd
@@ -155,9 +155,9 @@ DeclareAttribute( "ImageRecogNode", IsRecogNode, "mutable" );
 ## <#/GAPDoc>
 DeclareAttribute( "KernelRecogNode", IsRecogNode, "mutable" );
 
-## <#GAPDoc Label="RIParent">
+## <#GAPDoc Label="ParentRecogNode">
 ## <ManSection>
-## <Attr Name="RIParent" Arg="ri"/>
+## <Attr Name="ParentRecogNode" Arg="ri"/>
 ## <Description>
 ##     The value of this attribute is the recognition node of the
 ##     parent of this node in the recognition tree. The top node does not
@@ -165,7 +165,8 @@ DeclareAttribute( "KernelRecogNode", IsRecogNode, "mutable" );
 ## </Description>
 ## </ManSection>
 ## <#/GAPDoc>
-DeclareAttribute( "RIParent", IsRecogNode, "mutable" );
+DeclareAttribute( "ParentRecogNode", IsRecogNode, "mutable" );
+DeclareObsoleteSynonymAttr( "RIParent", "ParentRecogNode", 1 );
 
 ## <#GAPDoc Label="StdPresentation">
 ## <ManSection>
@@ -250,9 +251,9 @@ DeclareAttribute( "slptonice", IsRecogNode, "mutable" );
 ## <#/GAPDoc>
 DeclareAttribute( "fhmethsel", IsRecogNode, "mutable" );      # TODO: rename?
 
-## <#GAPDoc Label="methodsforfactor">
+## <#GAPDoc Label="methodsforimage">
 ## <ManSection>
-## <Attr Name="methodsforfactor" Arg="ri"/>
+## <Attr Name="methodsforimage" Arg="ri"/>
 ## <Description>
 ##     This attribute is initialised at the beginning of the recursive
 ##     recognition function with the database of find homomorphism methods
@@ -268,7 +269,8 @@ DeclareAttribute( "fhmethsel", IsRecogNode, "mutable" );      # TODO: rename?
 ## </Description>
 ## </ManSection>
 ## <#/GAPDoc>
-DeclareAttribute( "methodsforfactor", IsRecogNode, "mutable" ); # rename to MethodsDBForFactor
+DeclareAttribute( "methodsforimage", IsRecogNode, "mutable" ); # rename to MethodsDBForFactor
+DeclareObsoleteSynonymAttr( "methodsforfactor", "methodsforimage", 1 );
 
 ## <#GAPDoc Label="slpforelement">
 ## <ManSection>
@@ -302,9 +304,11 @@ DeclareAttribute( "gensNslp", IsRecogNode, "mutable" );
 # Do we have to do an immediate verification of the kernel?
 DeclareAttribute( "immediateverification", IsRecogNode, "mutable" );
 # Used to transport information about the group down to the kernel:
-DeclareAttribute( "forkernel", IsRecogNode, "mutable" );
+DeclareAttribute( "InitialDataForKernelRecogNode", IsRecogNode, "mutable" );
+DeclareObsoleteSynonymAttr( "forkernel", "InitialDataForKernelRecogNode", 1 );
 # Used to transport information about the group down to the image:
-DeclareAttribute( "forfactor", IsRecogNode, "mutable" );
+DeclareAttribute( "InitialDataForImageRecogNode", IsRecogNode, "mutable" );
+DeclareObsoleteSynonymAttr( "forfactor", "InitialDataForImageRecogNode", 1 );
 # Used to check whether group elements are equal to one after recognition:
 DeclareAttribute( "isone", IsRecogNode, "mutable" );
 # Used to compare group elements after recognition:

--- a/gap/base/recognition.gi
+++ b/gap/base/recognition.gi
@@ -147,9 +147,9 @@ InstallGlobalFunction( EmptyRecognitionInfoRecord,
     Setslpforelement(ri,SLPforElementGeneric);
     SetgensN(ri,[]);       # this will grow over time
     Setimmediateverification(ri,false);
-    Setforkernel(ri,rec(hints := []));
+    SetInitialDataForKernelRecogNode(ri,rec(hints := []));
           # this is eventually handed down to the kernel
-    Setforfactor(ri,rec(hints := []));
+    SetInitialDataForImageRecogNode(ri,rec(hints := []));
           # this is eventually handed down to the image
     if projective then
         Setisone(ri,IsOneProjective);
@@ -452,7 +452,7 @@ InstallGlobalFunction( RecogniseGeneric,
         ri := EmptyRecognitionInfoRecord(knowledge,H,false);
     fi;
     # was here earlier: Setcalcnicegens(ri,CalcNiceGensGeneric);
-    Setmethodsforfactor(ri,methoddb);
+    Setmethodsforimage(ri,methoddb);
 
     # Find a possible homomorphism (or recognise this group as leaf)
     allmethods := methoddb;
@@ -538,11 +538,11 @@ InstallGlobalFunction( RecogniseGeneric,
         Add(depthString,'F');
         rifac := RecogniseGeneric(
                   Group(List(GeneratorsOfGroup(H), x->ImageElm(Homom(ri),x))),
-                  methodsforfactor(ri), depthString, forfactor(ri) ); # TODO: change forfactor to hintsForFactor??)
+                  methodsforimage(ri), depthString, InitialDataForImageRecogNode(ri) ); # TODO: change InitialDataForImageRecogNode to hintsForFactor??)
         Remove(depthString);
         PrintTreePos("F",depthString,H);
         SetImageRecogNode(ri,rifac);
-        SetRIParent(rifac,ri);
+        SetParentRecogNode(rifac,ri);
 
         if IsMatrixGroup(H) then
             Info(InfoRecog,2,"Back from image (depth=",depth,
@@ -612,11 +612,11 @@ InstallGlobalFunction( RecogniseGeneric,
         N := Group(StripMemory(gensN(ri)));
 
         Add(depthString,'K');
-        riker := RecogniseGeneric( N, methoddb, depthString, forkernel(ri) );
+        riker := RecogniseGeneric( N, methoddb, depthString, InitialDataForKernelRecogNode(ri) );
         Remove(depthString);
         PrintTreePos("K",depthString,H);
         SetKernelRecogNode(ri,riker);
-        SetRIParent(riker,ri);
+        SetParentRecogNode(riker,ri);
         Info(InfoRecog,2,"Back from kernel (depth=",depth,").");
 
         done := true;

--- a/gap/generic/KnownNilpotent.gi
+++ b/gap/generic/KnownNilpotent.gi
@@ -103,10 +103,10 @@ function(ri,G)
   H := GroupWithGenerators(gensfac);
   hom := GroupHomByFuncWithData(G,H,RECOG.HomForNilpotent,data);
   SetHomom(ri,hom);
-  forfactor(ri).primes := primes{[1..cut]};
-  forkernel(ri).primes := primes{[cut+1..Length(primes)]};
-  AddMethod(forfactor(ri).hints, FindHomMethodsGeneric.KnownNilpotent, 4000);
-  AddMethod(forkernel(ri).hints, FindHomMethodsGeneric.KnownNilpotent, 4000);
+  InitialDataForImageRecogNode(ri).primes := primes{[1..cut]};
+  InitialDataForKernelRecogNode(ri).primes := primes{[cut+1..Length(primes)]};
+  AddMethod(InitialDataForImageRecogNode(ri).hints, FindHomMethodsGeneric.KnownNilpotent, 4000);
+  AddMethod(InitialDataForKernelRecogNode(ri).hints, FindHomMethodsGeneric.KnownNilpotent, 4000);
   Append(gensN(ri),gensker);
   findgensNmeth(ri).method := FindKernelDoNothing;  # kernel already known
   ri!.leavegensNuntouched := true;

--- a/gap/matrix.gi
+++ b/gap/matrix.gi
@@ -72,7 +72,7 @@ function(ri, G)
   findgensNmeth(ri).method := FindKernelDoNothing;
 
   # Hint to the image:
-  AddMethod(forfactor(ri).hints, FindHomMethodsMatrix.Scalar, 4000);
+  AddMethod(InitialDataForImageRecogNode(ri).hints, FindHomMethodsMatrix.Scalar, 4000);
 
   return Success;
 end);
@@ -110,7 +110,7 @@ end);
 #  SetHomom(ri,hom);
 #
 #  # Hint to the kernel:
-#  forkernel(ri).containedinsl := true;
+#  InitialDataForKernelRecogNode(ri).containedinsl := true;
 #  return true;
 #end;
 
@@ -232,7 +232,7 @@ function(ri, G)
       H := GroupWithGenerators(newgens);
       hom := GroupHomByFuncWithData(G,H,RECOG.HomToDiagonalBlock,data);
       SetHomom(ri,hom);
-      AddMethod(forfactor(ri).hints, FindHomMethodsMatrix.Scalar, 2000);
+      AddMethod(InitialDataForImageRecogNode(ri).hints, FindHomMethodsMatrix.Scalar, 2000);
 
       if nrblocks = 1 then     # no kernel:
           findgensNmeth(ri).method := FindKernelDoNothing;
@@ -241,10 +241,10 @@ function(ri, G)
           # That should be easily and efficiently possible at this point, no?
           findgensNmeth(ri).args[1] := 7;
           findgensNmeth(ri).args[2] := 5;
-          forkernel(ri).blocks := ri!.blocks{[1]};
+          InitialDataForKernelRecogNode(ri).blocks := ri!.blocks{[1]};
           # We have to go to BlockScalar with 1 block because the one block
           # is only a part of the whole matrix:
-          AddMethod(forkernel(ri).hints, FindHomMethodsMatrix.BlockScalar, 2000);
+          AddMethod(InitialDataForKernelRecogNode(ri).hints, FindHomMethodsMatrix.BlockScalar, 2000);
           Setimmediateverification(ri,true);
       fi;
       return Success;
@@ -260,17 +260,17 @@ function(ri, G)
   SetHomom(ri,hom);
 
   # the image are the last few blocks:
-  forfactor(ri).blocks := List(ri!.blocks{[middle..nrblocks]},
+  InitialDataForImageRecogNode(ri).blocks := List(ri!.blocks{[middle..nrblocks]},
                                x->x - (ri!.blocks[middle][1]-1));
-  AddMethod(forfactor(ri).hints, FindHomMethodsMatrix.BlockScalar, 2000);
+  AddMethod(InitialDataForImageRecogNode(ri).hints, FindHomMethodsMatrix.BlockScalar, 2000);
 
   # the kernel is the first few blocks (can be only one!):
   # FIXME: why don't we just compute a precise set of generators of the kernel?
   # That should be easily and efficiently possible at this point, no?
   findgensNmeth(ri).args[1] := 3 + nrblocks;
   findgensNmeth(ri).args[2] := 5;
-  forkernel(ri).blocks := ri!.blocks{[1..middle-1]};
-  AddMethod(forkernel(ri).hints, FindHomMethodsMatrix.BlockScalar, 2000);
+  InitialDataForKernelRecogNode(ri).blocks := ri!.blocks{[1..middle-1]};
+  AddMethod(InitialDataForKernelRecogNode(ri).hints, FindHomMethodsMatrix.BlockScalar, 2000);
   Setimmediateverification(ri,true);
   return Success;
 end);
@@ -418,8 +418,8 @@ function(ri,G)
   findgensNmeth(ri).method := FindKernelDoNothing;
 
   # Inform authorities that the image can be recognised easily:
-  forfactor(ri).blocks := bc.blocks;
-  AddMethod(forfactor(ri).hints, FindHomMethodsMatrix.BlockLowerTriangular, 4000);
+  InitialDataForImageRecogNode(ri).blocks := bc.blocks;
+  AddMethod(InitialDataForImageRecogNode(ri).hints, FindHomMethodsMatrix.BlockLowerTriangular, 4000);
 
   return Success;
 end);
@@ -494,12 +494,12 @@ function(ri,G)
   SetHomom(ri,hom);
 
   # Now give hints downward:
-  forfactor(ri).blocks := ri!.blocks;
-  AddMethod(forfactor(ri).hints, FindHomMethodsMatrix.BlockDiagonal, 2000);
+  InitialDataForImageRecogNode(ri).blocks := ri!.blocks;
+  AddMethod(InitialDataForImageRecogNode(ri).hints, FindHomMethodsMatrix.BlockDiagonal, 2000);
   findgensNmeth(ri).method := FindKernelLowerLeftPGroup;
   findgensNmeth(ri).args := [];
-  AddMethod(forkernel(ri).hints, FindHomMethodsMatrix.LowerLeftPGroup, 2000);
-  forkernel(ri).blocks := ri!.blocks;
+  AddMethod(InitialDataForKernelRecogNode(ri).hints, FindHomMethodsMatrix.LowerLeftPGroup, 2000);
+  InitialDataForKernelRecogNode(ri).blocks := ri!.blocks;
   return Success;
 end);
 
@@ -532,11 +532,11 @@ function(ri,G)
   # will automatically take care of the projectiveness!
   SetHomom(ri, IdentityMapping(G));
   # Now give hints downward:
-  forfactor(ri).blocks := ri!.blocks;
-  AddMethod(forfactor(ri).hints, FindHomMethodsProjective.BlocksModScalars, 2000);
+  InitialDataForImageRecogNode(ri).blocks := ri!.blocks;
+  AddMethod(InitialDataForImageRecogNode(ri).hints, FindHomMethodsProjective.BlocksModScalars, 2000);
   # We go to projective, although it would not matter here, because we
   # gave a working hint anyway:
-  Setmethodsforfactor(ri,FindHomDbProjective);
+  Setmethodsforimage(ri,FindHomDbProjective);
 
   # the kernel:
   findgensNmeth(ri).args[1] := Length(ri!.blocks)+10;
@@ -545,13 +545,13 @@ function(ri,G)
   # to a matrix group by multiplying things such that the last block
   # becomes an identity matrix:
   if ri!.projective then
-      AddMethod(forkernel(ri).hints,
+      AddMethod(InitialDataForKernelRecogNode(ri).hints,
                 FindHomMethodsProjective.BlockScalarProj,
                 2000);
   else
-      AddMethod(forkernel(ri).hints, FindHomMethodsMatrix.BlockScalar, 2000);
+      AddMethod(InitialDataForKernelRecogNode(ri).hints, FindHomMethodsMatrix.BlockScalar, 2000);
   fi;
-  forkernel(ri).blocks := ri!.blocks;
+  InitialDataForKernelRecogNode(ri).blocks := ri!.blocks;
   return Success;
 end);
 
@@ -583,8 +583,8 @@ end);
 #  SetHomom(ri,hom);
 #
 #  # Inform authorities that the kernel can be recognised easily:
-#  forkernel(ri).subdim := ri!.subdim;
-#  AddMethod(forkernel(ri).hints, FindHomMethodsMatrix.InducedOnSubspace, 2000);
+#  InitialDataForKernelRecogNode(ri).subdim := ri!.subdim;
+#  AddMethod(InitialDataForKernelRecogNode(ri).hints, FindHomMethodsMatrix.InducedOnSubspace, 2000);
 #
 #  return true;
 #end;
@@ -717,11 +717,11 @@ InstallGlobalFunction( FindKernelLowerLeftPGroup,
         fi;
     od;
     # Now make sure those things get handed down to the kernel:
-    forkernel(ri).gensNvectors := lvec;
-    forkernel(ri).gensNpivots := pivots;
-    forkernel(ri).blocks := ri!.blocks;
-    forkernel(ri).lens := lens;
-    forkernel(ri).basisOfFieldExtension := basisOfFieldExtension;
+    InitialDataForKernelRecogNode(ri).gensNvectors := lvec;
+    InitialDataForKernelRecogNode(ri).gensNpivots := pivots;
+    InitialDataForKernelRecogNode(ri).blocks := ri!.blocks;
+    InitialDataForKernelRecogNode(ri).lens := lens;
+    InitialDataForKernelRecogNode(ri).basisOfFieldExtension := basisOfFieldExtension;
     # this is stored on the upper level:
     SetgensN(ri,l);
     ri!.leavegensNuntouched := true;
@@ -815,7 +815,7 @@ function(ri,G)
   hom := IdentityMapping(G);
   SetHomom(ri,hom);
   # Now give hints downward:
-  Setmethodsforfactor(ri,FindHomDbProjective);
+  Setmethodsforimage(ri,FindHomDbProjective);
   # note that RecogniseGeneric detects the use of FindHomDbProjective and
   # sets ri!.projective := true for the image
   # the kernel:
@@ -842,8 +842,8 @@ function(ri,G)
       S := StoredStabilizerChain(G);
       hom := OrbActionHomomorphism(G,S!.orb);
       SetHomom(ri,hom);
-      Setmethodsforfactor(ri,FindHomDbPerm);
-      forkernel(ri).StabilizerChainFromAbove := S;
+      Setmethodsforimage(ri,FindHomDbPerm);
+      InitialDataForKernelRecogNode(ri).StabilizerChainFromAbove := S;
       return Success;
   elif IsBound(ri!.StabilizerChainFromAbove) then
       Info(InfoRecog,2,"Know stabilizer chain for super group, using base.");
@@ -851,8 +851,8 @@ function(ri,G)
       Info(InfoRecog,2,"Computed stabilizer chain, size=",Size(S));
       hom := OrbActionHomomorphism(G,S!.orb);
       SetHomom(ri,hom);
-      Setmethodsforfactor(ri,FindHomDbPerm);
-      forkernel(ri).StabilizerChainFromAbove := S;
+      Setmethodsforimage(ri,FindHomDbPerm);
+      InitialDataForKernelRecogNode(ri).StabilizerChainFromAbove := S;
       return Success;
   fi;
   return NeverApplicable;
@@ -890,14 +890,14 @@ end);
 #  fi;
 #
 #  SetHomom(ri,hom);
-#  Setmethodsforfactor(ri,FindHomDbPerm);
+#  Setmethodsforimage(ri,FindHomDbPerm);
 #  return true;
 #end;
 #
 #FindHomMethodsMatrix.IsomorphismPermGroup := function(ri,G)
 #  SetHomom(ri,IsomorphismPermGroup(G));
 #  findgensNmeth(ri).method := FindKernelDoNothing;
-#  Setmethodsforfactor(ri,FindHomDbPerm);
+#  Setmethodsforimage(ri,FindHomDbPerm);
 #  return true;
 #end;
 

--- a/gap/matrix/matimpr.gi
+++ b/gap/matrix/matimpr.gi
@@ -200,9 +200,9 @@ function(ri,G)
           Info(InfoRecog,2,"Found block system with ",Length(res.orb),
                " blocks.");
           # A block system: We do a base change isomorphism:
-          forkernel(ri).t := Concatenation(res.orb);
-          forkernel(ri).blocksize := Length(res.orb[1]);
-          AddMethod(forkernel(ri).hints, FindHomMethodsProjective.DoBaseChangeForBlocks, 2000);
+          InitialDataForKernelRecogNode(ri).t := Concatenation(res.orb);
+          InitialDataForKernelRecogNode(ri).blocksize := Length(res.orb[1]);
+          AddMethod(InitialDataForKernelRecogNode(ri).hints, FindHomMethodsProjective.DoBaseChangeForBlocks, 2000);
           Setimmediateverification(ri,true);
           findgensNmeth(ri).args[1] := Length(res.orb)+3;
           findgensNmeth(ri).args[2] := 5;
@@ -210,7 +210,7 @@ function(ri,G)
 
       # we are done, report the hom:
       SetHomom(ri,res.hom);
-      Setmethodsforfactor(ri,FindHomDbPerm);
+      Setmethodsforimage(ri,FindHomDbPerm);
 
       return Success;
   fi;
@@ -236,8 +236,8 @@ function(ri,G)
   findgensNmeth(ri).method := FindKernelDoNothing;
 
   # Inform authorities that the image can be recognised easily:
-  forfactor(ri).blocksize := ri!.blocksize;
-  AddMethod(forfactor(ri).hints, FindHomMethodsProjective.Blocks, 2000);
+  InitialDataForImageRecogNode(ri).blocksize := ri!.blocksize;
+  AddMethod(InitialDataForImageRecogNode(ri).hints, FindHomMethodsProjective.Blocks, 2000);
 
   return Success;
 end);
@@ -259,11 +259,11 @@ function(ri,G)
       Add(blocks,[(i-1)*ri!.blocksize+1..i*ri!.blocksize]);
   od;
   # For the image:
-  forfactor(ri).blocks := blocks;
-  AddMethod(forfactor(ri).hints, FindHomMethodsProjective.BlocksModScalars, 2000);
+  InitialDataForImageRecogNode(ri).blocks := blocks;
+  AddMethod(InitialDataForImageRecogNode(ri).hints, FindHomMethodsProjective.BlocksModScalars, 2000);
   # For the kernel:
-  forkernel(ri).blocks := blocks;
-  AddMethod(forkernel(ri).hints, FindHomMethodsProjective.BlocksBackToMats, 2000);
+  InitialDataForKernelRecogNode(ri).blocks := blocks;
+  AddMethod(InitialDataForKernelRecogNode(ri).hints, FindHomMethodsProjective.BlocksBackToMats, 2000);
   return Success;
 end);
 
@@ -290,9 +290,9 @@ function(ri,G)
   SetHomom(ri,hom);
 
   # hints for the image:
-  Setmethodsforfactor(ri,FindHomDbMatrix);
-  forfactor(ri).blocks := ri!.blocks{[1..Length(ri!.blocks)-1]};
-  AddMethod(forfactor(ri).hints, FindHomMethodsMatrix.BlockScalar, 2000 );
+  Setmethodsforimage(ri,FindHomDbMatrix);
+  InitialDataForImageRecogNode(ri).blocks := ri!.blocks{[1..Length(ri!.blocks)-1]};
+  AddMethod(InitialDataForImageRecogNode(ri).hints, FindHomMethodsMatrix.BlockScalar, 2000 );
 
   # This is an isomorphism:
   findgensNmeth(ri).method := FindKernelDoNothing;
@@ -325,13 +325,13 @@ end);
 #  findgensNmeth(ri).args[1] := 20 + nrblocks;
 #
 #  # Pass the block information on to the image:
-#  forfactor(ri).blocksize := ri!.blocksize;
-#  AddMethod(forfactor(ri).hints, FindHomMethodsProjective.BalTreeForBlocks, 2000);
+#  InitialDataForImageRecogNode(ri).blocksize := ri!.blocksize;
+#  AddMethod(InitialDataForImageRecogNode(ri).hints, FindHomMethodsProjective.BalTreeForBlocks, 2000);
 #
 #  # Inform authorities that the kernel can be recognised easily:
-#  forkernel(ri).subdim := subdim;
-#  forkernel(ri).blocksize := ri!.blocksize;
-#  AddMethod(forkernel(ri).hints, FindHomMethodsProjective.BalTreeForBlocksProjKernel, 2000);
+#  InitialDataForKernelRecogNode(ri).subdim := subdim;
+#  InitialDataForKernelRecogNode(ri).blocksize := ri!.blocksize;
+#  AddMethod(InitialDataForKernelRecogNode(ri).hints, FindHomMethodsProjective.BalTreeForBlocksProjKernel, 2000);
 #
 #  # Verify the kernel immediately after its recognition:
 #  Setimmediateverification(ri,true);
@@ -371,8 +371,8 @@ end);
 #  findgensNmeth(ri).args := [];
 #
 #  # Inform authorities that the kernel can be recognised easily:
-#  forkernel(ri).subdim := ri!.subdim;
-#  AddMethod(forkernel(ri).hints, FindHomMethodsMatrix.LowerLeftPGroup, 2000);
+#  InitialDataForKernelRecogNode(ri).subdim := ri!.subdim;
+#  AddMethod(InitialDataForKernelRecogNode(ri).hints, FindHomMethodsMatrix.LowerLeftPGroup, 2000);
 #
 #  return Success;
 #end;
@@ -391,8 +391,8 @@ end);
 #  findgensNmeth(ri).method := FindKernelDoNothing;
 #
 #  # But pass on the information on blocks:
-#  forfactor(ri).blocksize := ri!.blocksize;
-#  AddMethod(forfactor(ri).hints, FindHomMethodsProjective.BalTreeForBlocks, 2000);
+#  InitialDataForImageRecogNode(ri).blocksize := ri!.blocksize;
+#  AddMethod(InitialDataForImageRecogNode(ri).hints, FindHomMethodsProjective.BalTreeForBlocks, 2000);
 #
 #  return Success;
 #end;

--- a/gap/perm.gi
+++ b/gap/perm.gi
@@ -122,9 +122,9 @@ function(ri, G)
     # the restriction to one block is solvable, which would mean, that
     # the kernel is solvable and that a hint is in order:
     Setimmediateverification(ri,true);
-    forkernel(ri).blocks := blocks;
-    AddMethod(forkernel(ri).hints, FindHomMethodsPerm.PcgsForBlocks, 400);
-    AddMethod(forkernel(ri).hints, FindHomMethodsPerm.BalTreeForBlocks, 200);
+    InitialDataForKernelRecogNode(ri).blocks := blocks;
+    AddMethod(InitialDataForKernelRecogNode(ri).hints, FindHomMethodsPerm.PcgsForBlocks, 400);
+    AddMethod(InitialDataForKernelRecogNode(ri).hints, FindHomMethodsPerm.BalTreeForBlocks, 200);
     findgensNmeth(ri).args[1] := Length(blocks)+3;
     findgensNmeth(ri).args[2] := 5;
     return Success;
@@ -181,7 +181,7 @@ function(ri, G)
   lowerhalf := blocks{[1..cut]};
   upperhalf := blocks{[cut+1..nrblocks]};
   o := Concatenation(upperhalf);
-  # The order of 'o' in the homom must align with forfactor(ri).blocks below
+  # The order of 'o' in the homom must align with InitialDataForImageRecogNode(ri).blocks below
   hom := ActionHomomorphism(G,o);
 
   # Make a set so checking validatehomominput is faster
@@ -194,12 +194,12 @@ function(ri, G)
   if nrblocks - cut > 1 then
       l := Length(upperhalf[1]);
       n := Length(upperhalf);
-      forfactor(ri).blocks := List([1..n],i->[(i-1)*l+1..i*l]);
-      AddMethod(forfactor(ri).hints, FindHomMethodsPerm.BalTreeForBlocks, 200);
+      InitialDataForImageRecogNode(ri).blocks := List([1..n],i->[(i-1)*l+1..i*l]);
+      AddMethod(InitialDataForImageRecogNode(ri).hints, FindHomMethodsPerm.BalTreeForBlocks, 200);
   fi;
   if cut > 1 then
-      forkernel(ri).blocks := lowerhalf;
-      AddMethod(forkernel(ri).hints, FindHomMethodsPerm.BalTreeForBlocks, 200);
+      InitialDataForKernelRecogNode(ri).blocks := lowerhalf;
+      AddMethod(InitialDataForKernelRecogNode(ri).hints, FindHomMethodsPerm.BalTreeForBlocks, 200);
   fi;
   return Success;
 end);

--- a/gap/projective.gi
+++ b/gap/projective.gi
@@ -69,7 +69,7 @@ function(ri, G)
       hom := GroupHomByFuncWithData(G,H,RECOG.HomToDiagonalBlock,data);
       SetHomom(ri,hom);
       # The following is already be set, but make it explicit here:
-      Setmethodsforfactor(ri,FindHomDbProjective);
+      Setmethodsforimage(ri,FindHomDbProjective);
       # no kernel:
       findgensNmeth(ri).method := FindKernelDoNothing;
       return Success;
@@ -85,11 +85,11 @@ function(ri, G)
 
   # the image are the last few blocks:
   # The following is already be set, but make it explicit here:
-  Setmethodsforfactor(ri,FindHomDbProjective);
+  Setmethodsforimage(ri,FindHomDbProjective);
   if middle < nrblocks then   # more than one block in image:
-      forfactor(ri).blocks := List(ri!.blocks{[middle..nrblocks]},
+      InitialDataForImageRecogNode(ri).blocks := List(ri!.blocks{[middle..nrblocks]},
                                    x->x - (ri!.blocks[middle][1]-1));
-      AddMethod(forfactor(ri).hints,
+      AddMethod(InitialDataForImageRecogNode(ri).hints,
                 FindHomMethodsProjective.BlocksModScalars,
                 2000);
   fi; # Otherwise the image is to be recognised projectively as usual
@@ -98,8 +98,8 @@ function(ri, G)
   findgensNmeth(ri).args[1] := 10 + nrblocks;
   findgensNmeth(ri).args[2] := 5 + middle - 1;
   # The following is already set, but make it explicit here:
-  forkernel(ri).blocks := ri!.blocks{[1..middle-1]};
-  AddMethod(forkernel(ri).hints, FindHomMethodsProjective.BlocksModScalars, 2000);
+  InitialDataForKernelRecogNode(ri).blocks := ri!.blocks{[1..middle-1]};
+  AddMethod(InitialDataForKernelRecogNode(ri).hints, FindHomMethodsProjective.BlocksModScalars, 2000);
   Setimmediateverification(ri,true);
   return Success;
 end);
@@ -143,7 +143,7 @@ function(ri, G)
   else
       ForgetMemory(S);
       SetHomom(ri,OrbActionHomomorphism(G,S!.orb));
-      Setmethodsforfactor(ri,FindHomDbPerm);
+      Setmethodsforimage(ri,FindHomDbPerm);
   fi;
   return Success;
 end);
@@ -187,7 +187,7 @@ function(ri, G)
   hom := GroupHomByFuncWithData(G,H,RECOG.HomProjDet,
                                 rec(c := c, z := z, gcd := gcd));
   SetHomom(ri,hom);
-  Setmethodsforfactor(ri,FindHomDbPerm);
+  Setmethodsforimage(ri,FindHomDbPerm);
   findgensNmeth(ri).args[1] := 8;
   findgensNmeth(ri).args[2] := 5;
   Setimmediateverification(ri,true);
@@ -255,9 +255,9 @@ function(ri, G)
   findgensNmeth(ri).method := FindKernelDoNothing;  # This is an iso
 
   # Switch to matrix mode:
-  Setmethodsforfactor(ri,FindHomDbMatrix);
-  AddMethod(forfactor(ri).hints, FindHomMethodsMatrix.BlockScalar, 2000);
-  forfactor(ri).blocks := ri!.blocks{[1..Length(ri!.blocks)-1]};
+  Setmethodsforimage(ri,FindHomDbMatrix);
+  AddMethod(InitialDataForImageRecogNode(ri).hints, FindHomMethodsMatrix.BlockScalar, 2000);
+  InitialDataForImageRecogNode(ri).blocks := ri!.blocks{[1..Length(ri!.blocks)-1]};
   return Success;
 end);
 

--- a/gap/projective/almostsimple.gi
+++ b/gap/projective/almostsimple.gi
@@ -287,9 +287,9 @@ InstallGlobalFunction( DoHintedLowIndex, function(ri,G,hint)
                   hom := OrbActionHomomorphism(G,orb);
                   if Length(s) * Length(orb) = d then
                       # A block system!
-                      forkernel(ri).t := Concatenation(orb);
-                      forkernel(ri).blocksize := Length(s);
-                      AddMethod(forkernel(ri).hints,
+                      InitialDataForKernelRecogNode(ri).t := Concatenation(orb);
+                      InitialDataForKernelRecogNode(ri).blocksize := Length(s);
+                      AddMethod(InitialDataForKernelRecogNode(ri).hints,
                                 FindHomMethodsProjective.DoBaseChangeForBlocks,
                                 2000);
                       Setimmediateverification(ri,true);
@@ -302,7 +302,7 @@ InstallGlobalFunction( DoHintedLowIndex, function(ri,G,hint)
                            Length(orb)," - not a block system.");
                   fi;
                   SetHomom(ri,hom);
-                  Setmethodsforfactor(ri,FindHomDbPerm);
+                  Setmethodsforimage(ri,FindHomDbPerm);
                   return true;
               fi;
           else
@@ -974,7 +974,7 @@ function(ri,G)
               hom := GroupHomByFuncWithData(G,GG,RECOG.HomFDPM,r);
 
               SetHomom(ri,hom);
-              Setmethodsforfactor(ri,FindHomDbPerm);
+              Setmethodsforimage(ri,FindHomDbPerm);
 
               ri!.comment := "_FDPM";
               return Success;

--- a/gap/projective/c3c5.gi
+++ b/gap/projective/c3c5.gi
@@ -173,19 +173,19 @@ function(ri, G)
   SetHomom(ri,hom);
 
   # Hand down hint that no MeatAxe run can help:
-  forfactor(ri).isabsolutelyirred := true;
+  InitialDataForImageRecogNode(ri).isabsolutelyirred := true;
 
   # There might be a kernel, because we have more scalars over the bigger
   # field, so go for it, however, fewer generators should suffice:
   # Also, doing normal closure will not help!
   findgensNmeth(ri).args := [5,0];
-  AddMethod(forkernel(ri).hints,
+  AddMethod(InitialDataForKernelRecogNode(ri).hints,
             FindHomMethodsProjective.BiggerScalarsOnly,
             2000);
-  forkernel(ri).degsplittingfield := MTX.DegreeSplittingField(m)
+  InitialDataForKernelRecogNode(ri).degsplittingfield := MTX.DegreeSplittingField(m)
                                    / DegreeOverPrimeField(f);
-  forkernel(ri).biggerscalarsbas := r.inforec.bas;
-  forkernel(ri).biggerscalarsbasi := r.inforec.basi;
+  InitialDataForKernelRecogNode(ri).biggerscalarsbas := r.inforec.bas;
+  InitialDataForKernelRecogNode(ri).biggerscalarsbasi := r.inforec.basi;
 
   return Success;
 end);
@@ -212,7 +212,7 @@ function(ri, G)
   hom := GroupHomByFuncWithData(G, Group(H), RECOG.HomBCToDiagonalBlock, data);
   SetHomom(ri,hom);
 
-  AddMethod(forfactor(ri).hints,
+  AddMethod(InitialDataForImageRecogNode(ri).hints,
             FindHomMethodsProjective.StabilizerChainProj,
             4000);
 
@@ -520,7 +520,7 @@ function(ri, G)
           H := GroupWithGenerators(gensim);
           hom := GroupHomByFuncWithData(G,H,RECOG.HomCommutator,r);
           SetHomom(ri,hom);
-          Setmethodsforfactor(ri,FindHomDbMatrix);
+          Setmethodsforimage(ri,FindHomDbMatrix);
           poss := Filtered([1..Length(gensim)],i->IsOne(gensim[i]));
           Append(gensN(ri),ri!.gensHmem{poss});
           findgensNmeth(ri).args[1] := 5;
@@ -627,7 +627,7 @@ function(ri, G)
       hom := GroupHomByFuncWithData(G,HH,RECOG.HomActionFieldAuto,
                   rec( c := c,cc := cc,cgen := cgen, cyc := cyc ) );
       SetHomom(ri,hom);
-      Setmethodsforfactor(ri,FindHomDbPerm);
+      Setmethodsforimage(ri,FindHomDbPerm);
       return Success;
 
       # The kernel will be semilinear directly, however, we have to
@@ -676,9 +676,9 @@ function(ri, G)
           SetHomom(ri,hom);
 
           # Hand down information:
-          forfactor(ri).blocksize := r.blocksize;
-          forfactor(ri).generatorskronecker := kro;
-          AddMethod(forfactor(ri).hints,
+          InitialDataForImageRecogNode(ri).blocksize := r.blocksize;
+          InitialDataForImageRecogNode(ri).generatorskronecker := kro;
+          AddMethod(InitialDataForImageRecogNode(ri).hints,
                     FindHomMethodsProjective.KroneckerProduct,
                     4000);
           # This is an isomorphism:
@@ -699,7 +699,7 @@ function(ri, G)
       Enumerate(o);
       a := OrbActionHomomorphism(G,o);
       SetHomom(ri,a);
-      Setmethodsforfactor(ri,FindHomDbPerm);
+      Setmethodsforimage(ri,FindHomDbPerm);
 
       return Success;
 

--- a/gap/projective/c6.gi
+++ b/gap/projective/c6.gi
@@ -740,15 +740,15 @@ function(ri, G)
         hom := GroupHomByFuncWithData(G,GroupWithGenerators(re.igens),
                  RECOG.HomFuncActionOnBlocks,
                  rec(r := re.r,n := re.n,q := re.q,blks := re.basis.blocks));
-        forkernel(ri).t := re.basis.blocks.blocks;
-        forkernel(ri).blocksize := ri!.dimension / re.basis.blocks.ell;
-        AddMethod(forkernel(ri).hints,
+        InitialDataForKernelRecogNode(ri).t := re.basis.blocks.blocks;
+        InitialDataForKernelRecogNode(ri).blocksize := ri!.dimension / re.basis.blocks.ell;
+        AddMethod(InitialDataForKernelRecogNode(ri).hints,
                   FindHomMethodsProjective.DoBaseChangeForBlocks,
                   2000);
         Setimmediateverification(ri,true);
         findgensNmeth(ri).args[1] := re.basis.blocks.ell + 3;
         findgensNmeth(ri).args[2] := 5;
-        Setmethodsforfactor(ri,FindHomDbPerm);
+        Setmethodsforimage(ri,FindHomDbPerm);
     else
         Info(InfoRecog,2,"C6: Found homomorphism.");
         hom := GroupHomByFuncWithData(G,GroupWithGenerators(re.igens),
@@ -757,7 +757,7 @@ function(ri, G)
         findgensNmeth(ri).args[1] := 3 + re.n;
         findgensNmeth(ri).args[2] := 5;
         Setimmediateverification(ri,true);
-        Setmethodsforfactor(ri,FindHomDbMatrix);
+        Setmethodsforimage(ri,FindHomDbMatrix);
     fi;
     SetHomom(ri,hom);
 

--- a/gap/projective/d247.gi
+++ b/gap/projective/d247.gi
@@ -250,9 +250,9 @@ RECOG.SortOutReducibleNormalSubgroup :=
         SetHomom(ri,hom);
 
         # Hand down information:
-        forfactor(ri).blocksize := r.blocksize;
-        forfactor(ri).generatorskronecker := kro;
-        AddMethod(forfactor(ri).hints,
+        InitialDataForImageRecogNode(ri).blocksize := r.blocksize;
+        InitialDataForImageRecogNode(ri).generatorskronecker := kro;
+        AddMethod(InitialDataForImageRecogNode(ri).hints,
                   FindHomMethodsProjective.KroneckerProduct,
                   4000);
         # This is an isomorphism:
@@ -294,7 +294,7 @@ ConvertToMatrixRep(homcomp,Size(f));
 
     a := OrbActionHomomorphism(G,o);
     SetHomom(ri,a);
-    Setmethodsforfactor(ri,FindHomDbPerm);
+    Setmethodsforimage(ri,FindHomDbPerm);
     ri!.comment := "_D2Imprimitive";
     Setimmediateverification(ri,true);
     findgensNmeth(ri).args[1] := Length(o)+6;
@@ -329,7 +329,7 @@ RECOG.SortOutReducibleSecondNormalSubgroup :=
                            RECOG.DirectFactorsAction,
                            rec( o := orb[1], eq := ri!.isequal) );
                 SetHomom(ri,hom);
-                Setmethodsforfactor(ri,FindHomDbPerm);
+                Setmethodsforimage(ri,FindHomDbPerm);
                 Info(InfoRecog,2,"D247: Success, found D7 with action",
                      " on ",mult," direct factors.");
                 ri!.comment := "_D7TensorInduced";

--- a/gap/projective/tensor.gi
+++ b/gap/projective/tensor.gi
@@ -352,7 +352,7 @@ function(ri,G)
       hom := ActionHomomorphism(G,r.orbit,OnSubspacesByCanonicalBasis,
                                 "surjective");
       SetHomom(ri,hom);
-      Setmethodsforfactor(ri,FindHomDbPerm);
+      Setmethodsforimage(ri,FindHomDbPerm);
       return Success;
   fi;
 
@@ -369,7 +369,7 @@ function(ri,G)
       hom := ActionHomomorphism(G,r.spaces,OnSubspacesByCanonicalBasis,
                                 "surjective");
       SetHomom(ri,hom);
-      Setmethodsforfactor(ri,FindHomDbPerm);
+      Setmethodsforimage(ri,FindHomDbPerm);
       return Success;
   fi;
 
@@ -378,9 +378,9 @@ function(ri,G)
   SetHomom(ri,hom);
 
   # Hand down information:
-  forfactor(ri).blocksize := r.blocksize;
-  forfactor(ri).generatorskronecker := kro;
-  AddMethod(forfactor(ri).hints, FindHomMethodsProjective.KroneckerProduct, 2000);
+  InitialDataForImageRecogNode(ri).blocksize := r.blocksize;
+  InitialDataForImageRecogNode(ri).generatorskronecker := kro;
+  AddMethod(InitialDataForImageRecogNode(ri).hints, FindHomMethodsProjective.KroneckerProduct, 2000);
   # This is an isomorphism:
   findgensNmeth(ri).method := FindKernelDoNothing;
   return Success;
@@ -411,8 +411,8 @@ function(ri, G)
   hom := GroupHomByFuncWithData(G,H,RECOG.HomTensorFactor,data);
   SetHomom(ri,hom);
 
-  AddMethod(forkernel(ri).hints, FindHomMethodsProjective.KroneckerKernel, 2000);
-  forkernel(ri).blocksize := ri!.blocksize;
+  AddMethod(InitialDataForKernelRecogNode(ri).hints, FindHomMethodsProjective.KroneckerKernel, 2000);
+  InitialDataForKernelRecogNode(ri).blocksize := ri!.blocksize;
   return Success;
 end);
 

--- a/misc/colva/Evaluate.g
+++ b/misc/colva/Evaluate.g
@@ -197,9 +197,9 @@ InstallGlobalFunction( NormalTree,
     SetgensN(ri,[]);       # this will grow over time
     SetfindgensNmeth(ri,rec(method := FindKernelRandom, args := [20]));
     Setimmediateverification(ri,false);
-    Setforkernel(ri,rec(hints := []));
+    SetInitialDataForKernelRecogNode(ri,rec(hints := []));
           # this is eventually handed down to the kernel
-    Setforfactor(ri,rec(hints := []));
+    SetInitialDataForImageRecogNode(ri,rec(hints := []));
           # this is eventually handed down to the image
 
 
@@ -230,7 +230,7 @@ InstallGlobalFunction( NormalTree,
     rifac := RecogniseLeaf(ri,I,name);;
 
      SetImageRecogNode(ri,rifac);
-     SetRIParent(rifac,ri);
+     SetParentRecogNode(rifac,ri);
 
      Info(InfoRecognition,1,"Back from image (depth=",depth,").");
 
@@ -295,7 +295,7 @@ InstallGlobalFunction( NormalTree,
 
         riker := NormalTree( N, nsm, depth+1 );;
         SetKernelRecogNode(ri,riker);
-        SetRIParent(riker,ri);
+        SetParentRecogNode(riker,ri);
         Info(InfoRecognition,1,"Back from kernel (depth=",depth,").");
 
         done := true;

--- a/misc/colva/Rearrange.g
+++ b/misc/colva/Rearrange.g
@@ -369,10 +369,10 @@ end);
  Objectify( RecognitionInfoType, nri );;
  SetImageRecogNode(nri,nrifac);
  SetGrp(nri,Grp(ri));
- if HasRIParent(ri) then
-   SetRIParent(nri,RIParent(ri));
-   SetKernelRecogNode(RIParent(nri),nri);
-   if not SanityCheck(RIParent(nri)) then
+ if HasParentRecogNode(ri) then
+   SetParentRecogNode(nri,ParentRecogNode(ri));
+   SetKernelRecogNode(ParentRecogNode(nri),nri);
+   if not SanityCheck(ParentRecogNode(nri)) then
      Error(1);
    fi;
  fi;
@@ -380,7 +380,7 @@ end);
    SetKernelRecogNode(nri, fail);
  elif HasKernelRecogNode(riker) then
    SetKernelRecogNode(nri,KernelRecogNode(riker));
-   SetRIParent(KernelRecogNode(nri),nri);
+   SetParentRecogNode(KernelRecogNode(nri),nri);
    if not SanityCheck(nri) then
      Error(2);
    fi;
@@ -434,25 +434,25 @@ SwapFactors := function(ri,zeta)
  Setpregensfac(nri,StructuralCopy(pregensfac(riker)));
  Setpregensfac(nriker,List(pregensfac(ri),x->x*ResultOfStraightLineProgram(SLPforElement(rikerfac,ImageElm(zeta,x)),pregensfac(riker))^-1));
  SetKernelRecogNode(nriker,StructuralCopy(KernelRecogNode(riker)));
- SetRIParent(KernelRecogNode(nriker),nriker);
- SetRIParent(nriker,nri);
+ SetParentRecogNode(KernelRecogNode(nriker),nriker);
+ SetParentRecogNode(nriker,nri);
  SetKernelRecogNode(nri, nriker);
  if not SanityCheck(nri) then
    Error(3);
  fi;
  SetImageRecogNode(nriker,StructuralCopy(ImageRecogNode(ri)));
  #next two lines had capital p for parent before.
- #if IsBound(ri!.RIParent) then not sure whether should be checking HasRIParent, try that instead.
- if HasRIParent(ri) then
-   SetRIParent(nri,StructuralCopy(RIParent(ri)));
-   SetKernelRecogNode(RIParent(nri),nri);
-   if not SanityCheck(RIParent(nri)) then
+ #if IsBound(ri!.ParentRecogNode) then not sure whether should be checking HasParentRecogNode, try that instead.
+ if HasParentRecogNode(ri) then
+   SetParentRecogNode(nri,StructuralCopy(ParentRecogNode(ri)));
+   SetKernelRecogNode(ParentRecogNode(nri),nri);
+   if not SanityCheck(ParentRecogNode(nri)) then
      Error(4);
    fi;
  fi;
  if HasKernelRecogNode(riker) then
    SetKernelRecogNode(nriker,KernelRecogNode(riker));
-   SetRIParent(KernelRecogNode(riker),nriker);
+   SetParentRecogNode(KernelRecogNode(riker),nriker);
    if not SanityCheck(nri) then
      Error(5);
    fi;
@@ -553,7 +553,7 @@ PushDown := function(pri)
      npri := SwapFactors(pri,zeta);;
    fi;
    View(npri);
-   if not SanityCheck(RIParent(npri)) then
+   if not SanityCheck(ParentRecogNode(npri)) then
      Error(101);
    fi;
    return npri;
@@ -574,7 +574,7 @@ PushDown := function(pri)
    if knpri <> false and npri <> false then
 #found a map that works.
      SetKernelRecogNode(npri,knpri);
-     SetRIParent(knpri,npri);
+     SetParentRecogNode(knpri,npri);
      if not SanityCheck(npri) then
        Error(6);
      fi;
@@ -616,8 +616,8 @@ OrderTree := function(ri)
  pri:= StructuralCopy(lastnonabri);
 
 # Push the soluble layers down
- while HasRIParent(pri) do
-   pri := StructuralCopy(RIParent(pri));
+ while HasParentRecogNode(pri) do
+   pri := StructuralCopy(ParentRecogNode(pri));
    SetNiceGens(pri,Concatenation(pregensfac(pri),NiceGens(KernelRecogNode(pri))));
    npri := PushDown(StructuralCopy(pri));;
    if npri <> false then
@@ -631,12 +631,12 @@ OrderTree := function(ri)
  #this is kind of messy, but i haven't managed to track down where all the
  #parent kernel factor not matching up errors are occurring
  while HasKernelRecogNode(pri) and not KernelRecogNode(pri) = fail do
-   SetRIParent(KernelRecogNode(pri), pri);
-   SetRIParent(ImageRecogNode(pri), pri);
+   SetParentRecogNode(KernelRecogNode(pri), pri);
+   SetParentRecogNode(ImageRecogNode(pri), pri);
    pri:= KernelRecogNode(pri);
  od;
- while HasRIParent(pri) do
-   pri:= RIParent(pri);
+ while HasParentRecogNode(pri) do
+   pri:= ParentRecogNode(pri);
  od;
  return pri;
 end;

--- a/misc/colva/Refine.g
+++ b/misc/colva/Refine.g
@@ -70,19 +70,19 @@ InsertSubTree := function(ri,rifac,maps)
    SetGrp(lri[i+1],GroupWithGenerators(kgens));
    SetKernelRecogNode(lri[i],lri[i+1]);
    SetImageRecogNode(lri[i],rri[i]);
-   SetRIParent(lri[i+1],lri[i]);
-   SetRIParent(rri[i],lri[i]);
+   SetParentRecogNode(lri[i+1],lri[i]);
+   SetParentRecogNode(rri[i],lri[i]);
  od;
 
 
- # tell lri[1] to join onto RIParent(ri)
- if HasRIParent(ri) then
-   SetRIParent(lri[1],StructuralCopy(RIParent(ri)));
+ # tell lri[1] to join onto ParentRecogNode(ri)
+ if HasParentRecogNode(ri) then
+   SetParentRecogNode(lri[1],StructuralCopy(ParentRecogNode(ri)));
  fi;
 
  # tell last lri to be kerfac
    SetKernelRecogNode(lri[Size(Q)],StructuralCopy(kerfac));
-   SetRIParent(KernelRecogNode(lri[Size(Q)]),lri[Size(Q)]);
+   SetParentRecogNode(KernelRecogNode(lri[Size(Q)]),lri[Size(Q)]);
 
  # Set up the nice generators
 
@@ -125,7 +125,7 @@ RefineSolubleLayers := function(ri)
   ri := InsertSubTree(ri, rifac, maps);;
   riker := KernelRecogNode(ri);
   SetKernelRecogNode(ri,RefineSolubleLayers(riker));
-  SetRIParent(KernelRecogNode(ri),ri);
+  SetParentRecogNode(KernelRecogNode(ri),ri);
   if KernelRecogNode(ri)<>fail then
     SetNiceGens(ri,Concatenation(pregensfac(ri),NiceGens(KernelRecogNode(ri))));
   else
@@ -201,7 +201,7 @@ SubgroupNC(Grp(ImageRecogNode(ri)),List(CS[i],v->VectortoPc(v,Grp(ImageRecogNode
   ri := InsertSubTree(ri, rifac, maps);;
   riker := KernelRecogNode(ri);
   SetKernelRecogNode(ri,RefineElementaryAbelianLayers(riker));
-  SetRIParent(KernelRecogNode(ri),ri);
+  SetParentRecogNode(KernelRecogNode(ri),ri);
   if KernelRecogNode(ri)<>fail then
     SetNiceGens(ri,Concatenation(pregensfac(ri),NiceGens(KernelRecogNode(ri))));
   else
@@ -222,15 +222,15 @@ RemoveTrivialLayers := function(ri)
  I := Grp(rifac);
  if IsPcGroup(I) and IsTrivial(I) then
 # I is trivial!!
-   if HasRIParent(ri) then
-     parri := StructuralCopy(RIParent(ri));
+   if HasParentRecogNode(ri) then
+     parri := StructuralCopy(ParentRecogNode(ri));
    fi;
    ri := riker;;
    if IsBound(parri) then
-     SetRIParent(ri,parri);
+     SetParentRecogNode(ri,parri);
    else
-     Unbind(ri!.RIParent);
-     ResetFilterObj(ri, HasRIParent);
+     Unbind(ri!.ParentRecogNode);
+     ResetFilterObj(ri, HasParentRecogNode);
    fi;
    newriker := KernelRecogNode(ri);
    SetKernelRecogNode(ri,RemoveTrivialLayers(newriker));

--- a/misc/colva/TopPerms.g
+++ b/misc/colva/TopPerms.g
@@ -56,8 +56,8 @@ P:= GroupWithGenerators(Pgens);
 
 #work up the tree, checking whether action is trivial (in
 #which case push down to Pker).
-while (HasRIParent(nri)) do
-  nri:= RIParent(nri);
+while (HasParentRecogNode(nri)) do
+  nri:= ParentRecogNode(nri);
 
   #now need to find the permutation action of the preimages of the
   #generators of  the image on the factors of the socle.

--- a/misc/colva/leaves.g
+++ b/misc/colva/leaves.g
@@ -124,7 +124,7 @@ function(ri,I,name)
  rifac := rec();
  Objectify(RecognitionInfoType,rifac);;
  SetFilterObj(rifac,IsLeaf);
- SetRIParent(rifac,ri);
+ SetParentRecogNode(rifac,ri);
  SetImageRecogNode(ri,rifac);
  SetGrp(rifac,I);
  if IsPcGroup(I) then

--- a/misc/colva/stuff.g
+++ b/misc/colva/stuff.g
@@ -8,18 +8,18 @@ nri:= StructuralCopy(ri);
 i:= 0;
 bool:= true;
 while HasKernelRecogNode(nri) and not KernelRecogNode(nri) = fail do
-  if not RIParent(ImageRecogNode(nri)) = nri then
+  if not ParentRecogNode(ImageRecogNode(nri)) = nri then
     Print("image error at level", i, "\n");
     bool:= false;
   fi;
-  if not RIParent(KernelRecogNode(nri)) = nri then
+  if not ParentRecogNode(KernelRecogNode(nri)) = nri then
     Print("error: at level", i, "\n");
     bool:= false;
   fi;
   nri:= KernelRecogNode(nri);
   i:= i+1;
 od;
-if not RIParent(ImageRecogNode(nri)) = nri then
+if not ParentRecogNode(ImageRecogNode(nri)) = nri then
   Print("image error at level", i, "\n");
 fi;
 return bool;

--- a/misc/obsolete/derived.gi
+++ b/misc/obsolete/derived.gi
@@ -92,9 +92,9 @@ FindHomMethodsProjective.Derived :=
         SetHomom(ri,hom);
 
         # Hand down information:
-        forfactor(ri).blocksize := r.blocksize;
-        forfactor(ri).generatorskronecker := kro;
-        Add( forfactor(ri).hints,
+        InitialDataForImageRecogNode(ri).blocksize := r.blocksize;
+        InitialDataForImageRecogNode(ri).generatorskronecker := kro;
+        Add( InitialDataForImageRecogNode(ri).hints,
              rec( method := FindHomMethodsProjective.KroneckerProduct,
                   rank := 4000, stamp := "KroneckerProduct" ) );
         # This is an isomorphism:
@@ -114,7 +114,7 @@ FindHomMethodsProjective.Derived :=
     Enumerate(o);
     a := OrbActionHomomorphism(G,o);
     SetHomom(ri,a);
-    Setmethodsforfactor(ri,FindHomDbPerm);
+    Setmethodsforimage(ri,FindHomDbPerm);
 
     return true;
   end;

--- a/misc/obsolete/semilinear.gi
+++ b/misc/obsolete/semilinear.gi
@@ -149,17 +149,17 @@ FindHomMethodsProjective.NotAbsolutelyIrred := function(ri,G)
   SetHomom(ri,hom);
 
   # Hand down hint that no MeatAxe run can help:
-  forfactor(ri).isabsolutelyirred := true;
+  InitialDataForImageRecogNode(ri).isabsolutelyirred := true;
 
   # There might be a kernel, because we have more scalars over the bigger
   # field, so go for it, however, some more generators might be in order,
   # Normal closure however is unnecessary.
   findgensNmeth(ri).args[1] := 5;
   findgensNmeth(ri).args[2] := 0;
-  Add(forkernel(ri).hints,
+  Add(InitialDataForKernelRecogNode(ri).hints,
       rec( method := FindHomMethodsProjective.BiggerScalarsOnly, rank := 2000,
            stamp := "BiggerScalarsOnly" ));
-  forkernel(ri).degsplittingfield := MTX.DegreeSplittingField(m)
+  InitialDataForKernelRecogNode(ri).degsplittingfield := MTX.DegreeSplittingField(m)
                                    / DegreeOverPrimeField(f);
 
   return true;
@@ -175,7 +175,7 @@ FindHomMethodsProjective.BiggerScalarsOnly := function(ri,G)
   hom := GroupHomByFuncWithData(G,H,RECOG.HomToDiagonalBlock,data);
   SetHomom(ri,hom);
 
-  Add(forfactor(ri).hints,
+  Add(InitialDataForImageRecogNode(ri).hints,
       rec( method := FindHomMethodsProjective.StabilizerChainProj, rank := 4000,
            stamp := "StabilizerChain" ));
 

--- a/misc/obsolete/shortorbs.gi
+++ b/misc/obsolete/shortorbs.gi
@@ -341,7 +341,7 @@ FindHomMethodsMatrix.ShortOrbits := function(ri,g)
   Info(InfoRecog,3,"Finished building homomorphism.");
 
   SetHomom(ri,hom);
-  Setmethodsforfactor(ri,FindHomDbPerm);
+  Setmethodsforimage(ri,FindHomDbPerm);
 
   return true;
 end;


### PR DESCRIPTION
This continues #253.

Renames as follows:
`RIParent` -> `ParentRecogNode`
`methodsforfactor` -> `methodsforimage`
`forfactor` -> `InitDataForImageRecogNode`
`forkernel` -> `InitDataForKernelRecogNode`

The documentation builds on my machine and I've checked a few cross-references and index entries. Everything looks fine there. `testquick.g` also passes on my machine. 

**Edit**: I've moved the whole nice generators business into a separate branch.