### PR TITLE
Improve printing of recog trees

### DIFF
--- a/gap/base/recognition.gi
+++ b/gap/base/recognition.gi
@@ -43,7 +43,7 @@ RECOG_ViewObj := function( level, ri )
             Print(ms);
         fi;
         if IsBound(ri!.comment) then
-            Print(ri!.comment);
+            Print(" Comment=", ri!.comment);
         fi;
     fi;
     if HasIsRecogInfoForSimpleGroup(ri) and IsRecogInfoForSimpleGroup(ri) then

--- a/gap/projective.gi
+++ b/gap/projective.gi
@@ -57,7 +57,7 @@ function(ri, G)
       Setslptonice( ri, StraightLineProgramNC([[[1,0]]],
                                               Length(GeneratorsOfGroup(G))));
       SetFilterObj(ri,IsLeaf);
-      ri!.comment := "_BlocksDim=1";
+      ri!.comment := "BlocksDim=1";
       return Success;
   fi;
 

--- a/gap/projective/almostsimple.gi
+++ b/gap/projective/almostsimple.gi
@@ -194,7 +194,7 @@ InstallGlobalFunction( DoHintedStabChain, function(ri,G,hint)
                 SetIsRecogInfoForSimpleGroup(ri,hint.issimple);
             fi;
             SetIsRecogInfoForAlmostSimpleGroup(ri,true);
-            ri!.comment := Concatenation("_",hint.name);
+            ri!.comment := hint.name;
             return true;
         od;
     fi;
@@ -976,7 +976,7 @@ function(ri,G)
               SetHomom(ri,hom);
               Setmethodsforimage(ri,FindHomDbPerm);
 
-              ri!.comment := "_FDPM";
+              ri!.comment := "FDPM";
               return Success;
           fi;
       fi;
@@ -1024,7 +1024,7 @@ function(ri,G)
 #           ForgetMemory(r[3][1]);
 #           SetFilterObj(ri,IsLeaf);
 #           SetIsRecogInfoForSimpleGroup(ri,true);
-#           ri!.comment := "_Alt";
+#           ri!.comment := "Alt";
 #           return Success;
 #       else   # r[1] = "Sn"
 #           Info(InfoRecog,2,"Found Sym(",deg,")!");
@@ -1037,7 +1037,7 @@ function(ri,G)
 #           ForgetMemory(r[3][1]);
 #           SetFilterObj(ri,IsLeaf);
 #           SetIsRecogInfoForAlmostSimpleGroup(ri,true);
-#           ri!.comment := "_Sym";
+#           ri!.comment := "Sym";
 #           return Success;
 #       fi;
 #   od;

--- a/gap/projective/almostsimple/lietype.gi
+++ b/gap/projective/almostsimple/lietype.gi
@@ -837,7 +837,7 @@ function(ri,G)
             # We found something:
             Info(InfoRecog,2,"LieTypeNonConstr: found ",r,
                  ", lookup up hints...");
-            ri!.comment := Concatenation("_",r);
+            ri!.comment := r;
             res := LookupHintForSimple(ri,G,r);
             # FIXME: LookupHintForSimple is for sporadics... So why do we use it here?
             if res = true then

--- a/gap/projective/classicalnatural.gi
+++ b/gap/projective/classicalnatural.gi
@@ -3246,10 +3246,10 @@ function(ri, g)
       Info(InfoRecog,2,"ClassicalNatural: this is PSL_2!");
       if IsEvenInt(q) then
           std := RECOG.RecogniseSL2NaturalEvenChar(gm,f,false);
-          ri!.comment := "_PSL2Even";
+          ri!.comment := "PSL2Even";
       else
           std := RECOG.RecogniseSL2NaturalOddCharUsingBSGS(gm,f);
-          ri!.comment := "_PSL2Odd";
+          ri!.comment := "PSL2Odd";
       fi;
       Setslptonice(ri,SLPOfElms(std.all));
       ri!.nicebas := std.bas;
@@ -3270,7 +3270,7 @@ function(ri, g)
               # FIXME: Note d=3 currently has a problem in the SL2-finder.
               Info(InfoRecog,2,"Classical natural: SL(",d,",",q,"): small ",
                    "case, handing over to Schreier-Sims.");
-              ri!.comment := Concatenation("_SL(",String(d),",",String(q),")",
+              ri!.comment := Concatenation("SL(",String(d),",",String(q),")",
                                            "_StabilizerChain");
               return FindHomMethodsProjective.StabilizerChainProj(ri,g);
           fi;
@@ -3285,7 +3285,7 @@ function(ri, g)
                       x->std.basi*x*std.bas));
           ri!.fakegens := RECOG.InitSLfake(f,d);
           ri!.fakegens.count := 0;
-          ri!.comment := "_PSLd";
+          ri!.comment := "PSLd";
           ri!.gcd := gcd;
           SetFilterObj(ri,IsLeaf);
           SetSize(ri,Product([0..d-1],i->(q^d-q^i))/((q-1)*gcd.gcd));

--- a/gap/projective/d247.gi
+++ b/gap/projective/d247.gi
@@ -257,7 +257,7 @@ RECOG.SortOutReducibleNormalSubgroup :=
                   4000);
         # This is an isomorphism:
         findgensNmeth(ri).method := FindKernelDoNothing;
-        ri!.comment := "_D4TensorDec";
+        ri!.comment := "D4TensorDec";
         return Success;
     fi;
     Info(InfoRecog,2,"D247:Using action on the set of homogeneous components",
@@ -295,7 +295,7 @@ ConvertToMatrixRep(homcomp,Size(f));
     a := OrbActionHomomorphism(G,o);
     SetHomom(ri,a);
     Setmethodsforimage(ri,FindHomDbPerm);
-    ri!.comment := "_D2Imprimitive";
+    ri!.comment := "D2Imprimitive";
     Setimmediateverification(ri,true);
     findgensNmeth(ri).args[1] := Length(o)+6;
     findgensNmeth(ri).args[2] := 4;
@@ -332,7 +332,7 @@ RECOG.SortOutReducibleSecondNormalSubgroup :=
                 Setmethodsforimage(ri,FindHomDbPerm);
                 Info(InfoRecog,2,"D247: Success, found D7 with action",
                      " on ",mult," direct factors.");
-                ri!.comment := "_D7TensorInduced";
+                ri!.comment := "D7TensorInduced";
                 return Success;
             else
                 Info(InfoRecog,2,"D247: Did not find direct factors!");

--- a/tst/working/quick/bugfix.tst
+++ b/tst/working/quick/bugfix.tst
@@ -31,25 +31,25 @@ gap> RECOG.TestGroup(SymmetricGroup(11), false, Factorial(11));
 # See https://github.com/gap-packages/recog/issues/65
 gap> RecogniseGroup(SL(2,2));
 <recognition node GoProjective Dim=2 Field=2
- F:<recognition node (projective) ClassicalNatural_PSL2Even Size=6 Dim=
-2 Field=2>
+ F:<recognition node (projective) ClassicalNatural Comment=PSL2Even Size=
+6 Dim=2 Field=2>
  K:<trivial kernel>
 gap> RecogniseGroup(SL(2,3));
 <recognition node GoProjective Dim=2 Field=3
- F:<recognition node (projective) ClassicalNatural_PSL2Odd Size=12 Dim=
-2 Field=3>
+ F:<recognition node (projective) ClassicalNatural Comment=PSL2Odd Size=
+12 Dim=2 Field=3>
  K:<recognition node DiagonalMatrices Dim=2 Field=3
     F:<recognition node Scalar Dim=1 Field=3>
     K:<trivial kernel>>
 gap> RecogniseGroup(SL(2,4));
 <recognition node GoProjective Dim=2 Field=4
- F:<recognition node (projective) ClassicalNatural_PSL2Even Simple Size=
-60 Dim=2 Field=4>
+ F:<recognition node (projective) ClassicalNatural Comment=PSL2Even Simple Siz\
+e=60 Dim=2 Field=4>
  K:<trivial kernel>
 gap> RecogniseGroup(SL(2,5));
 <recognition node GoProjective Dim=2 Field=5
- F:<recognition node (projective) ClassicalNatural_PSL2Odd Simple Size=60 Dim=
-2 Field=5>
+ F:<recognition node (projective) ClassicalNatural Comment=PSL2Odd Simple Size\
+=60 Dim=2 Field=5>
  K:<recognition node DiagonalMatrices Dim=2 Field=5
     F:<recognition node Scalar Dim=1 Field=5>
     K:<trivial kernel>>


### PR DESCRIPTION
Slightly change how nodes are printed. Previously, the name of the
successful method might be appended by a `comment` string. Now, if
there is a comment, it is printed in a separate `Comment:` field.

Thus also remove the leading underscore of the `ri!.comment` values.
