### PR TITLE
Improve RecogniseGeneric and document RecogNode

### DIFF
--- a/doc/recognition.xml
+++ b/doc/recognition.xml
@@ -205,6 +205,10 @@ known. A recognition node always represents a whole binary tree of such
 records, see the attributes <Ref Attr="ImageRecogNode"/> and <Ref Attr="KernelRecogNode"/>
 below. <P/>
 
+Recognition nodes can be created via:
+
+<#Include Label="RecogNode">
+
 The following filters are defined for recognition nodes:
 
 <#Include Label="IsLeaf">

--- a/gap/base/recognition.gd
+++ b/gap/base/recognition.gd
@@ -24,9 +24,29 @@ BindGlobal( "RecogNodeFamily",
   NewFamily("RecogNodeFamily", IsRecogNode));
 DeclareObsoleteSynonym( "RecognitionInfoFamily", "RecogNodeFamily" );
 # The type:
-BindGlobal( "RecognitionInfoType",
+BindGlobal( "RecogNodeType",
   NewType(RecogNodeFamily, IsRecogNode and IsAttributeStoringRep));
 
+## <#GAPDoc Label="RecogNode">
+## <ManSection>
+## <Oper Name="RecogNode" Arg="H[, projective][, r]"/>
+## <Oper Name="RecogNode" Arg="r, H, projective"/>
+## <Returns>a recognition node.</Returns>
+## <Description>
+## Create an <Ref Filt="IsRecogNode"/> object <C>node</C> representing the
+## group <A>H</A>.
+## The optional boolean <A>projective</A> defaults to false and specifies,
+## in the case that <A>H</A> is a matrix group, whether <A>H</A> is to be
+## interpreted as a projective group.
+## The optional record <A>r</A> defaults to an empty record and is used to
+## initialize the returned <C>node</C>.
+## <P/>
+## For backwards-compatibility, also the order of arguments
+## <C>r, H, projective</C> is accepted.
+## </Description>
+## </ManSection>
+## <#/GAPDoc>
+DeclareOperation( "RecogNode", [ IsGroup, IsBool, IsRecord ]);
 
 # The info class:
 DeclareInfoClass( "InfoRecog" );
@@ -449,8 +469,6 @@ BindGlobal( "SLPforElementFuncsGeneric", rec() );
 
 
 # Our global functions for the main recursion:
-
-DeclareGlobalFunction( "EmptyRecognitionInfoRecord" );
 
 ## <#GAPDoc Label="RecognisePermGroup">
 ## <ManSection>

--- a/gap/base/recognition.gd
+++ b/gap/base/recognition.gd
@@ -59,18 +59,19 @@ DeclareFilter( "IsLeaf" );
 ## <ManSection>
 ## <Filt Name="IsReady" Type="Flag"/>
 ## <Description>
-## This flag indicates during the recognition procedure, whether a node in
-## the recognition tree was recognized completely. For leaves this means that
-## recognition terminated without throwing errors. For non-leaf nodes this
-## means that a homomorphism was computed and both image and kernel nodes are
-## ready or non-existent (if the kernel is trivial).
+## This flag is set for a <Ref Filt="IsRecogNode"/> object <C>node</C> by <Ref
+## Func="RecogniseGeneric"/>, if recognition of the <E>subtree</E> rooted in
+## <C>node</C> finished successfully.
+## Recognition of a node is considered successful, if <Ref Func="CallMethods"/>
+## reports <K>Success</K>, that is if a method from the respective method
+## database (see Section <Ref Sect="methoddatabases"/>) was successful.
+## Thus, if the <Ref Filt="IsReady"/> flag is set, this does not necessarily
+## mean, that the result of the recognition procedure was verified and proven
+## to be mathematically correct!
 ## <P/>
-## This does not mean, that the result of the recognition procedure was
-## verified and proven to be mathematically correct!
-## <P/>
-## In particular, computing <Ref Oper="Size"/> and member ship test via <Ref
-## Oper="\\in"/> can only be done for <Ref Filt="IsRecogNode"/> objects which
-## have <Ref Filt="IsReady"/> set.
+## In particular, any computations using the datastructure set up by the
+## recognition procedure, like <Ref Oper="Size"/> and membership testing via
+## <Ref Oper="\\in"/>, will error if <Ref Filt="IsReady"/> is not set.
 ## </Description>
 ## </ManSection>
 ## <#/GAPDoc>

--- a/gap/base/recognition.gd
+++ b/gap/base/recognition.gd
@@ -82,9 +82,12 @@ DeclareFilter( "IsLeaf" );
 ## This flag is set for a <Ref Filt="IsRecogNode"/> object <C>node</C> by <Ref
 ## Func="RecogniseGeneric"/>, if recognition of the <E>subtree</E> rooted in
 ## <C>node</C> finished successfully.
-## Recognition of a node is considered successful, if <Ref Func="CallMethods"/>
-## reports <K>Success</K>, that is if a method from the respective method
-## database (see Section <Ref Sect="methoddatabases"/>) was successful.
+## Recognition of a node is considered successful, if two conditions hold.
+## First, the call of <Ref Func="CallMethods"/> for this node reports
+## <K>Success</K>, that is a method from the respective method database (see
+## Section <Ref Sect="methoddatabases"/>) was successful.
+## Secondly, the construction of the kernel generators was successful.
+## <P/>
 ## Thus, if the <Ref Filt="IsReady"/> flag is set, this does not necessarily
 ## mean, that the result of the recognition procedure was verified and proven
 ## to be mathematically correct!

--- a/gap/base/recognition.gi
+++ b/gap/base/recognition.gi
@@ -129,7 +129,7 @@ InstallGlobalFunction( RecogniseGroup,
 InstallGlobalFunction( TryFindHomMethod,
   function( g, method, projective )
     local result,ri;
-    ri := EmptyRecognitionInfoRecord(rec(),g,projective);
+    ri := RecogNode(g,projective);
     Unbind(g!.pseudorandomfunc);
     result := method(ri,g);
     if result in [TemporaryFailure, NeverApplicable] then
@@ -141,11 +141,13 @@ InstallGlobalFunction( TryFindHomMethod,
     fi;
   end );
 
-InstallGlobalFunction( EmptyRecognitionInfoRecord,
-  function(r,H,projective)
+InstallMethod( RecogNode,
+  "standard method",
+  [ IsGroup, IsBool, IsRecord ],
+  function(H,projective,r)
     local ri;
     ri := ShallowCopy(r);
-    Objectify( RecognitionInfoType, ri );
+    Objectify( RecogNodeType, ri );
     SetGrp(ri,H);
     Setslpforelement(ri,SLPforElementGeneric);
     SetgensN(ri,[]);       # this will grow over time
@@ -212,6 +214,20 @@ InstallGlobalFunction( EmptyRecognitionInfoRecord,
     return ri;
   end );
 
+InstallOtherMethod( RecogNode,
+  "for a group",
+  [ IsGroup ],
+  function(H)
+    return RecogNode(H, false, rec());
+  end );
+
+InstallOtherMethod( RecogNode,
+  "for a group and a boolean",
+  [ IsGroup, IsBool ],
+  function(H, projective)
+    return RecogNode(H, projective, rec());
+  end );
+
 # Sets the stamp used by RandomElm, RandomElmOrd, and related functions.
 RECOG.SetPseudoRandomStamp := function(g,st)
   if IsBound(g!.pseudorandomfunc) then
@@ -229,9 +245,9 @@ end;
 # if called with stamp := "B".
 #
 # The components of the recog record involved are explained in
-# EmptyRecognitionInfoRecord.
+# RecogNode.
 #
-# HACK: For recog records created by EmptyRecognitionInfoRecord the method
+# HACK: For recog records created by RecogNode the method
 # RandomElm is by default stored in the component ri!.Grp!.pseudorandomfunc.
 # A method for PseudoRandom is installed such that it calls
 # RandomElm(ri, "PseudoRandom", false).
@@ -452,10 +468,10 @@ InstallGlobalFunction( RecogniseGeneric,
     fi;
 
     # Set up the record and the group object:
-    ri := EmptyRecognitionInfoRecord(
-        knowledge,
+    ri := RecogNode(
         H,
-        IsIdenticalObj( methoddb, FindHomDbProjective )
+        IsIdenticalObj( methoddb, FindHomDbProjective ),
+        knowledge
     );
     # was here earlier: Setcalcnicegens(ri,CalcNiceGensGeneric);
     Setmethodsforimage(ri,methoddb);

--- a/gap/projective/almostsimple.gi
+++ b/gap/projective/almostsimple.gi
@@ -357,7 +357,7 @@ RECOG.ProduceTrivialStabChainHint := function(name,reps,maxes)
       for m in [1..Length(maxes)] do
           Print("Doing maximal subgroup #",m,"\n");
           hint := rec( name := name, size := size, usemax := [m] );
-          ri := EmptyRecognitionInfoRecord(rec(),g,true);
+          ri := RecogNode(rec(),g,true);
           t := Runtime();
           res := DoHintedStabChain(ri,g,hint);
           t := Runtime() - t;

--- a/misc/colva/DPleaf.g
+++ b/misc/colva/DPleaf.g
@@ -314,7 +314,7 @@ SolveLeafDP := function(ri,rifac,name)
  blk := GroupWithGenerators(List(GeneratorsOfGroup(H1),x->ImageElm(H1toblk,x)));
 
  riH1 := rec();
- Objectify(RecognitionInfoType,riH1);;
+ Objectify(RecogNodeType,riH1);;
 
  SetGrp(riH1,H1);
  blkdata := RecogniseLeaf(riH1,blk,name);;

--- a/misc/colva/Evaluate.g
+++ b/misc/colva/Evaluate.g
@@ -49,7 +49,7 @@ end;
 
 # lri := []; rri := [];
 # lri[1] := rec();
-# Objectify(RecognitionInfoType,lri[1]);;
+# Objectify(RecogNodeType,lri[1]);;
 
 # SetGrp(lri[1],Grp(ri));
 
@@ -125,7 +125,7 @@ end;
 #     b := Basis(B,VV);
 #     VPc := ElementaryAbelianGroup(p^Length(b));
 #     rri[count] := rec();
-#     Objectify(RecognitionInfoType,rri[count]);;
+#     Objectify(RecogNodeType,rri[count]);;
 #     SetGrp(rri[count],VPc);
 # Solve the rewriting problem with these gens
 #     P := Pcgs(VPc);
@@ -186,7 +186,7 @@ InstallGlobalFunction( NormalTree,
 
     # Set up the record and the group object:
     ri := ShallowCopy(knowledge);
-    Objectify( RecognitionInfoType, ri );;
+    Objectify( RecogNodeType, ri );;
     ri!.depth := depth;
     ri!.nrgensH := Length(GeneratorsOfGroup(H));
     Setovergroup(ri,nsm!.Group);

--- a/misc/colva/Rearrange.g
+++ b/misc/colva/Rearrange.g
@@ -342,7 +342,7 @@ end);
 
 # setup the new record for the factor - this is the product of ImageRecogNode(ri) and ImageRecogNode(riker)
  nrifac := rec();
- Objectify( RecognitionInfoType, nrifac );;
+ Objectify( RecogNodeType, nrifac );;
 
 #new factor group is direct product of old factor groups, both are now in the socle.
  SetGrp(nrifac,D);
@@ -366,7 +366,7 @@ end);
 # setup the new record for the subgroup - nri will take the place of the old ri, but iwth
 #ker(riker) as its kernel and nrifac, the new socle, as its factor.
  nri := rec();
- Objectify( RecognitionInfoType, nri );;
+ Objectify( RecogNodeType, nri );;
  SetImageRecogNode(nri,nrifac);
  SetGrp(nri,Grp(ri));
  if HasParentRecogNode(ri) then
@@ -425,9 +425,9 @@ SwapFactors := function(ri,zeta)
 
 # setup the new record for the factor
  nri := rec();
- Objectify( RecognitionInfoType, nri );;
+ Objectify( RecogNodeType, nri );;
  nriker := rec();
- Objectify( RecognitionInfoType, nriker );;
+ Objectify( RecogNodeType, nriker );;
 
  SetHomom(nriker,StructuralCopy(Homom(ri)));
  SetHomom(nri,zeta);

--- a/misc/colva/Refine.g
+++ b/misc/colva/Refine.g
@@ -24,7 +24,7 @@ InsertSubTree := function(ri,rifac,maps)
 
  lri := []; rri := [];
  lri[1] := rec();
- Objectify(RecognitionInfoType,lri[1]);;
+ Objectify(RecogNodeType,lri[1]);;
 
  SetGrp(lri[1],Grp(ri));
 
@@ -34,7 +34,7 @@ InsertSubTree := function(ri,rifac,maps)
 
  for i in [1..Length(Q)] do
    rri[i] := rec();
-   Objectify(RecognitionInfoType,rri[i]);;
+   Objectify(RecogNodeType,rri[i]);;
    SetGrp(rri[i],Q[i]);
    SetHomom(lri[i],GtoQ[i]);
    SetNiceGens(rri[i],AsList(Pcgs(Q[i])));
@@ -66,7 +66,7 @@ InsertSubTree := function(ri,rifac,maps)
      kgens := [One(overgp)];
    fi;
    lri[i+1] := rec();
-   Objectify(RecognitionInfoType,lri[i+1]);;
+   Objectify(RecogNodeType,lri[i+1]);;
    SetGrp(lri[i+1],GroupWithGenerators(kgens));
    SetKernelRecogNode(lri[i],lri[i+1]);
    SetImageRecogNode(lri[i],rri[i]);

--- a/misc/colva/SimpleRecog.g
+++ b/misc/colva/SimpleRecog.g
@@ -186,7 +186,7 @@ RecogniseQuasiSimple := function(G,name)
  else
 # Use Shortotbits and consider the group as a perm grp
    re := rec();
-   Objectify(RecognitionInfoType,re);;
+   Objectify(RecogNodeType,re);;
    FindHomMethodsMatrix.ShortOrbits(re,G);
 # Perm Image
    GtoP := Homom(re);

--- a/misc/colva/leaves.g
+++ b/misc/colva/leaves.g
@@ -122,7 +122,7 @@ function(ri,I,name)
  local rifac,bool;
 
  rifac := rec();
- Objectify(RecognitionInfoType,rifac);;
+ Objectify(RecogNodeType,rifac);;
  SetFilterObj(rifac,IsLeaf);
  SetParentRecogNode(rifac,ri);
  SetImageRecogNode(ri,rifac);

--- a/read.g
+++ b/read.g
@@ -18,6 +18,7 @@
 ReadPackage("recog","gap/base/methods.gi");
 ReadPackage("recog","gap/base/methsel.gi");
 ReadPackage("recog","gap/base/recognition.gi");
+ReadPackage("recog","gap/obsolete.gi");
 
 # The following contain generic functionality for different types of groups:
 

--- a/tst/broken/quick/Sporadic.tst
+++ b/tst/broken/quick/Sporadic.tst
@@ -5,7 +5,7 @@ gap> TestSporadic := function(name)
 >     local g, ri;
 >     g := AtlasGenerators(name,1).generators;
 >     g := Group(g);
->     ri := EmptyRecognitionInfoRecord(rec(),g,IsMatrixGroup(g));
+>     ri := RecogNode(g,IsMatrixGroup(g));
 >     return FindHomMethodsProjective.NameSporadic(ri);
 > end;;
 

--- a/tst/working/combined/Sporadic.tst
+++ b/tst/working/combined/Sporadic.tst
@@ -5,7 +5,7 @@ gap> TestSporadic := function(name)
 >     local g, ri;
 >     g := AtlasGenerators(name,1).generators;
 >     g := Group(g);
->     ri := EmptyRecognitionInfoRecord(rec(),g,IsMatrixGroup(g));
+>     ri := RecogNode(g,IsMatrixGroup(g));
 >     return FindHomMethodsProjective.NameSporadic(ri, g : DEBUGRECOGSPORADICS);
 > end;;
 

--- a/tst/working/quick/GenericSnAnUnknownDegree.tst
+++ b/tst/working/quick/GenericSnAnUnknownDegree.tst
@@ -10,7 +10,7 @@ gap> AddMethod(FindHomDbProjective, FindHomMethodsGeneric.SnAnUnknownDegree, 122
 gap> for d in [11] do
 > sets := Combinations([1 .. d], 2);;
 > SdOn2Sets := Action(SymmetricGroup(d), sets, OnSets);;
-> ri := EmptyRecognitionInfoRecord(rec(), SdOn2Sets, false);;
+> ri := RecogNode(SdOn2Sets);;
 > success := FindHomMethodsGeneric.SnAnUnknownDegree(ri, SdOn2Sets);
 > if not success or not Size(ri) = Factorial(d) then
 >   Print("wrong result! degree ", d, "\n");
@@ -21,7 +21,7 @@ gap> for d in [11] do
 gap> for d in [11] do
 > sets := Combinations([1 .. d], 2);;
 > SdOn2Sets := Action(AlternatingGroup(d), sets, OnSets);;
-> ri := EmptyRecognitionInfoRecord(rec(), SdOn2Sets, false);;
+> ri := RecogNode(SdOn2Sets);;
 > success := FindHomMethodsGeneric.SnAnUnknownDegree(ri, SdOn2Sets);
 > if not success or not Size(ri) = Factorial(d)/2 then
 >   Print("wrong result! degree ", d, "\n");
@@ -29,7 +29,7 @@ gap> for d in [11] do
 > od;
 
 # Check Slp function
-gap> ri := EmptyRecognitionInfoRecord(rec(), SdOn2Sets, false);;
+gap> ri := RecogNode(SdOn2Sets);;
 gap> FindHomMethodsGeneric.SnAnUnknownDegree(ri, SdOn2Sets);
 true
 gap> x := PseudoRandom(Grp(ri));;

--- a/tst/working/slow/GenericSnAnUnknownDegree.tst
+++ b/tst/working/slow/GenericSnAnUnknownDegree.tst
@@ -24,7 +24,7 @@ gap> AddMethod(FindHomDbProjective, FindHomMethodsGeneric.SnAnUnknownDegree, 122
 # tests RECOG.ThreeCycleCandidatesIterator and RECOG.BolsteringElements
 gap> testFunction := function(G, eps, N)
 >     local ri, iterator, candidate, i, j;
->     ri := EmptyRecognitionInfoRecord(rec(), G, false);
+>     ri := RecogNode(G);
 >     iterator := RECOG.ThreeCycleCandidatesIterator(ri, RECOG.ThreeCycleCandidatesConstants(eps, N));
 >     for i in [1 .. 4] do
 >         candidate := iterator();
@@ -137,13 +137,13 @@ gap> for i in [1 .. Length(altMatGroups)] do
 >     RECOG.TestGroup(altMatGroups[i], true, Size(altMatGroups[i]));
 > od;
 gap> for i in [1 .. Length(nonAltOrSymGroups)] do
->     if FindHomMethodsGeneric.SnAnUnknownDegree(EmptyRecognitionInfoRecord(rec(), nonAltOrSymGroups[i], false), nonAltOrSymGroups[i]) = Success then
+>     if FindHomMethodsGeneric.SnAnUnknownDegree(RecogNode(nonAltOrSymGroups[i]), nonAltOrSymGroups[i]) = Success then
 >         Print("ERROR: Recognised group [", i, "] wrongly as Sn/An!\n");
 >     fi;
 > od;
 
 # RECOG.IsFixedPoint
-gap> ri := EmptyRecognitionInfoRecord(rec(), SymmetricGroup(10), false);;
+gap> ri := RecogNode(SymmetricGroup(10));;
 gap> g := (1,2,3,4,5,6,7,8);;
 gap> c := (1,2,3);;
 gap> r := (1,2)(4,5,6);;
@@ -154,7 +154,7 @@ gap> RECOG.IsFixedPoint(ri, g,c,r);
 false
 
 # RECOG.AdjustCycle
-gap> ri := EmptyRecognitionInfoRecord(rec(), SymmetricGroup(10), false);;
+gap> ri := RecogNode(SymmetricGroup(10));;
 gap> g := (1,2,3,4,5,6,7,8);;
 gap> c := (1,2,3);;
 gap> r := (4,5);;
@@ -189,7 +189,7 @@ gap> RECOG.AdjustCycle(ri, g, c, r, 8);
 (3,5,4,6)
 
 # RECOG.BuildCycle
-gap> ri := EmptyRecognitionInfoRecord(rec(), SymmetricGroup(10), false);;
+gap> ri := RecogNode(SymmetricGroup(10));;
 
 # c = (u,v,w)
 gap> c := (1,2,3);;
@@ -250,7 +250,7 @@ gap> RECOG.BuildCycle(ri, c, x, 10);
 # representation.
 gap> sets := Combinations([1 .. 11], 2);;
 gap> S11On2Sets := Action(SymmetricGroup(11), sets, OnSets);;
-gap> ri := EmptyRecognitionInfoRecord(rec(), S11On2Sets, false);;
+gap> ri := RecogNode(S11On2Sets);;
 gap> FindHomMethodsGeneric.SnAnUnknownDegree(ri, S11On2Sets);;
 gap> isoData := ri!.SnAnUnknownDegreeIsoData;;
 gap> gens := GeneratorsOfGroup(S11On2Sets);;
@@ -270,7 +270,7 @@ gap> CycleStructurePerm(img2);
 gap> for d in [11 .. 14] do
 > sets := Combinations([1 .. d], 2);;
 > SdOn2Sets := Action(SymmetricGroup(d), sets, OnSets);;
-> ri := EmptyRecognitionInfoRecord(rec(), SdOn2Sets, false);;
+> ri := RecogNode(SdOn2Sets);;
 > success := FindHomMethodsGeneric.SnAnUnknownDegree(ri, SdOn2Sets);
 > if not success or not Size(ri) = Factorial(d) then
 >   Print("wrong result! degree ", d, "\n");
@@ -281,7 +281,7 @@ gap> for d in [11 .. 14] do
 gap> for d in [11 .. 14] do
 > sets := Combinations([1 .. d], 2);;
 > SdOn2Sets := Action(AlternatingGroup(d), sets, OnSets);;
-> ri := EmptyRecognitionInfoRecord(rec(), SdOn2Sets, false);;
+> ri := RecogNode(SdOn2Sets);;
 > success := FindHomMethodsGeneric.SnAnUnknownDegree(ri, SdOn2Sets);
 > if not success or not Size(ri) = Factorial(d)/2 then
 >   Print("wrong result! degree ", d, "\n");
@@ -289,7 +289,7 @@ gap> for d in [11 .. 14] do
 > od;
 
 # Check Slp function
-gap> ri := EmptyRecognitionInfoRecord(rec(), S11On2Sets, false);;
+gap> ri := RecogNode(S11On2Sets);;
 gap> FindHomMethodsGeneric.SnAnUnknownDegree(ri, S11On2Sets);
 true
 gap> x := PseudoRandom(Grp(ri));;


### PR DESCRIPTION
- Improve documentation of IsReady
- Improve RecogniseGeneric
  - Clean up of comments.
  - Some refactoring.
  - Improve the warning message if recognition of a node does not
    terminate. Since IsReady is not set, an error will be thrown once one
    wants do something with the recognition data structure. Thus it is not
    necessary to throw an error in RecogniseGeneric. Make
    sure that, if everything went fine, then IsReady is set directly
    before returning.
- Rename and document recognition node constructor
  - Also rename the corresponding type.
    Rename as follows:
    RecognitionInfoType -> RecogNodeType
    EmptyRecognitionInfoRecord -> RecogNode

