### PR TITLE
Test the min GAP version

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -30,6 +30,7 @@ jobs:
           - stable-4.14
           - stable-4.13
           - stable-4.12
+          - stable-4.11
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
The `PackageInfo.g` states that the min GAP version is 4.11. So, we should either test this or increase the min version to 4.12. This PR tries to test against 4.11. We'll see how this works out.