### PR TITLE
Increase min GAP version

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -266,7 +266,7 @@ PackageDoc := rec(
 ),
 
 Dependencies := rec(
-  GAP := ">=4.11",
+  GAP := ">=4.12",
   NeededOtherPackages := [
     ["AtlasRep", ">= 1.4.0"],
     ["FactInt", ">= 1.5.2"],


### PR DESCRIPTION
Since #350 is failing we should increase the min GAP version to 4.12.