### PR TITLE
Remove table of unused methods from documentation

### DIFF
--- a/doc/methods.xml
+++ b/doc/methods.xml
@@ -67,8 +67,6 @@ in fact are installed as methods for projective groups.
 
 The following table gives an overview over the methods which are currently unused.
 
-<#Include SYSTEM "_methods_unused_table.xml">
-
 </Section>
 
 <!-- ############################################################ -->

--- a/regen_doc.g
+++ b/regen_doc.g
@@ -96,32 +96,6 @@ local xmlfile, meth;
 
 end;
 
-GenerateUnusedMethodsTableXML := function()
-    local xmlfile, meth;
-
-    xmlfile := "doc/_methods_unused_table.xml";
-    xmlfile := OutputTextFile(xmlfile, false);
-    SetPrintFormattingStatus(xmlfile, false);
-
-    PrintTo(xmlfile, "<Table Align=\"|l|l|l|\">\n");
-    AppendTo(xmlfile, "<Caption>Unused group find homomorphism methods</Caption>\n");
-    AppendTo(xmlfile, "<HorLine/>\n");
-
-    for meth in ListOfUnusedMethods() do
-        AppendTo(xmlfile, "<Row>\n");
-        AppendTo(xmlfile, "<Item><C>", meth[1], "</C></Item>\n");
-        AppendTo(xmlfile, "<Item><C>", meth[2], "</C></Item>\n");
-        AppendTo(xmlfile, "<Item><Ref Subsect=\"", meth[1], "\"/></Item>\n");
-        AppendTo(xmlfile, "</Row>\n");
-        AppendTo(xmlfile, "<HorLine/>\n");
-    od;
-
-    AppendTo(xmlfile, "</Table>\n");
-
-    CloseStream(xmlfile);
-
-end;
-
 GenerateMethodsListXML := function(shortname, db)
     local xmlfile, dbsWhichUseMethod, nrDbsWhichUseMethod, s, meth;
 
@@ -163,8 +137,6 @@ end;
 GenerateMethodsTableXML("matrix", "Matrix", FindHomDbMatrix);
 GenerateMethodsTableXML("perm", "Permutation", FindHomDbPerm);
 GenerateMethodsTableXML("proj", "Projective", FindHomDbProjective);
-
-GenerateUnusedMethodsTableXML();
 
 GenerateMethodsListXML("generic", FindHomMethodsGeneric);
 GenerateMethodsListXML("matrix", FindHomMethodsMatrix);


### PR DESCRIPTION
This table was misleading: most of these methods *are* used, just
not in the top-level tables, but rather only based on hints.
