### PR TITLE
Fix RECOG.HomProjDet to correctly deal with scalar multiples

### DIFF
--- a/gap/projective.gi
+++ b/gap/projective.gi
@@ -150,8 +150,20 @@ function(ri)
 end);
 
 RECOG.HomProjDet := function(data,m)
-  local x;
-  x := LogFFE(DeterminantMat(m),data.z);
+  local i, mm, x;
+  # Since the input is projective, it may be scaled out of the node's base
+  # field. Normalize by the first non-zero entry in the first row; then either
+  # all entries lie in the base field, or else the input is invalid.
+  i := PositionNonZero(m[1]);
+  mm := m;
+  if not mm[1,i] in data.field then
+      mm := mm / mm[1,i];
+  fi;
+  # verify the matrix is defined over data.field, or a subfield
+  if not IsSubset(data.field, FieldOfMatrixList([mm])) then
+      return fail;
+  fi;
+  x := LogFFE(DeterminantMat(mm),data.z);
   if x = fail then
       return fail;
   fi;
@@ -168,7 +180,7 @@ end;
 BindRecogMethod(FindHomMethodsProjective, "ProjDeterminant",
 "find homomorphism to non-zero scalars mod d-th powers",
 function(ri)
-  local G,H,c,d,detsadd,f,gcd,hom,newgens,q,z;
+  local G,H,c,d,data,detsadd,f,gcd,hom,newgens,q,z;
   G := Grp(ri);
   f := ri!.field;
   d := ri!.dimension;
@@ -186,9 +198,10 @@ function(ri)
   c := PermList(Concatenation([2..gcd],[1]));
   newgens := List(detsadd,x->c^x);
   H := GroupWithGenerators(newgens);
-  hom := GroupHomByFuncWithData(G,H,RECOG.HomProjDet,
-                                rec(c := c, z := z, gcd := gcd));
+  data := rec(c := c, z := z, gcd := gcd, field := f);
+  hom := GroupHomByFuncWithData(G,H,RECOG.HomProjDet,data);
   SetHomom(ri,hom);
+  Setvalidatehomominput(ri, {ri,x} -> RECOG.HomProjDet(data, x) <> fail);
   Setmethodsforimage(ri,FindHomDbPerm);
   findgensNmeth(ri).args[1] := 8;
   findgensNmeth(ri).args[2] := 5;

--- a/gap/projective/tensor.gi
+++ b/gap/projective/tensor.gi
@@ -100,13 +100,6 @@ RECOG.FindTensorDecomposition := function(G,N)
       Add(n,MTX.ProperSubmoduleBasis(m[i+1]));
       i := i + 1;
   od;
-  i := i - 1;
-  b := n[i];
-  i := i - 1;
-  while i >= 1 do
-      b := b * n[i];
-      i := i - 1;
-  od;
 
   # Compute the homogeneous component:
   w := m[Length(m)];   # An irreducible FN-module
@@ -307,17 +300,19 @@ end;
 
 
 #! @BeginChunk TensorDecomposable
-#! TODO/FIXME: it is unclear if the following description actually belongs
-#! to this method, so be cautious!
+#! This method looks for the tensor-decomposable situation described in
+#! <Cite Key="Neu09" Where="Section VII.(6.6)"/>. It first searches for a
+#! non-scalar normal subgroup
+#! whose restriction to the natural module is homogeneous. From such a
+#! subgroup it reconstructs a basis in which the group acts by Kronecker
+#! products. If the homogeneous constituent is not absolutely irreducible,
+#! then the same setup instead points to a semilinear structure; otherwise it
+#! yields a genuine tensor decomposition.
 #! 
-#! 
-#! This method currently tries to find one tensor factor by powering up
-#! commutators of random elements to elements of prime order. This seems
-#! to work quite well provided that the two tensor factors are not
-#! <Q>linked</Q> too much such that there exist enough elements that act
-#! with different orders on both tensor factors.
-#! 
-#! This method and its description needs some improvement.
+#! In practical terms the implementation starts from random elements and their
+#! commutators to obtain suitable normal subgroups, then uses MeatAxe data for
+#! the restriction to that subgroup to build the actual tensor basis, as in
+#! Lemma VII.6.6 and Theorem VII.6.7 of <Cite Key="Neu09"/>.
 #! @EndChunk
 BindRecogMethod(FindHomMethodsProjective, "TensorDecomposable",
 "find a tensor decomposition",
@@ -396,10 +391,22 @@ RECOG.HomTensorFactor := function(data,m)
 end;
 
 #! @BeginChunk KroneckerProduct
-#! TODO
+#! This method is only used after a previous step has already found a tensor
+#! decomposition and rewritten the generators accordingly. It projects to one
+#! tensor factor, recognises that factor projectively, and then continues with
+#! the other factor in the kernel.
+#!
+#! The underlying tensor-decomposition argument is the one used for the
+#! tensor-decomposable case in <Cite Key="Neu09"
+#! Where="Section VII.(6.6), especially pp. 125-126"/>: after a suitable base
+#! change, and using the constructive reduction from Theorem VII.6.7, each
+#! group element acts as a Kronecker product on
+#! <M>V_1 \otimes_{\mathbb{F}_q} V_2</M>. In projective recognition one has to allow
+#! for scalar ambiguity in the extracted tensor factor, so the generic
+#! projective SLP machinery must treat representatives up to scalars.
 #! @EndChunk
 BindRecogMethod(FindHomMethodsProjective, "KroneckerProduct",
-"TODO",
+"split off one factor of a tensor decomposition projectively",
 function(ri)
   # We got the hint that this is a Kronecker product, let's take it apart.
   # We first recognise projectively in one tensor factor and then in the
@@ -425,10 +432,18 @@ RECOG.HomTensorKernel := function(data,m)
 end;
 
 #! @BeginChunk KroneckerKernel
-#! TODO
+#! This method handles the kernel left behind by
+#! <Ref Subsect="KroneckerProduct" Style="Text"/>. In that kernel the second
+#! tensor factor is projectively scalar, so every element is represented by a
+#! block-diagonal matrix with identical diagonal blocks. The homomorphism used
+#! here simply projects to one of those blocks.
+#!
+#! As for <Ref Subsect="KroneckerProduct" Style="Text"/>, this is part of the
+#! tensor-decomposition strategy discussed in <Cite Key="Neu09"
+#! Where="Section VII.(6.6), especially p. 126"/>.
 #! @EndChunk
 BindRecogMethod(FindHomMethodsProjective, "KroneckerKernel",
-"TODO",
+"project from the tensor kernel to the repeated diagonal block",
 function(ri)
   # One up in the tree we got the hint about a Kronecker product, this
   # method is called when we have gone to one factor and now are in the

--- a/tst/working/quick/bugfix.tst
+++ b/tst/working/quick/bugfix.tst
@@ -16,7 +16,7 @@ gap> outsider:=Reversed(IdentityMat(4,GF(2)));;
 gap> outsider in ri;
 false
 
-# Issue #16
+# See https://github.com/gap-packages/recog/issues/16
 gap> g := DirectProduct(SymmetricGroup(12),SymmetricGroup(5));;
 gap> for i in [1..30] do
 >   h:=g^Random(SymmetricGroup(37));
@@ -24,7 +24,7 @@ gap> for i in [1..30] do
 >   if Size(r) <> Size(g) then ErrorNoReturn("wrong size"); fi;
 > od;
 
-# verify issue #38 is resolved
+# See https://github.com/gap-packages/recog/issues/38
 gap> RECOG.TestGroup(SymmetricGroup(11), false, Factorial(11));
 <recognition node Giant AlmostSimple Size=39916800>
 
@@ -79,7 +79,7 @@ gap> RECOG.SmallHomomorphicImageProjectiveGroup(G);  # this call used to raise a
 fail
 
 # Bug in RECOG.ForceToOtherField when working over large, non-internal fields
-# See <https://github.com/gap-packages/recog/issues/383>
+# See https://github.com/gap-packages/recog/issues/383
 gap> m:=[[Z(17^4)^290]];;
 gap> RECOG.ForceToOtherField(m,GF(17,2)) = m;
 true
@@ -89,6 +89,40 @@ true
 # produce a failed recognition node on the branch for issue #399.
 gap> i:=4;; Reset(GlobalRandomSource,i);; Reset(GlobalMersenneTwister,1);;
 gap> ri:=RecognizeGroup(SO(+1,4,3));;
+gap> IsReady(ri);
+true
+
+# A projective tensor-factor image used to miss scalar multiples, so this
+# reproducible seed produced a failed KroneckerProduct node.
+# See https://github.com/gap-packages/recog/issues/302
+gap> z := Z(3^2);;
+gap> gens := [ [ [ z^0, z^3, z^7, z^0, z^6, z^5, z^5, z^2 ],
+>       [ z^4, z^5, z^6, z^2, z^6, z^3, z^0, z^0 ],
+>       [ z^5, 0*z, z^4, z, z^3, 0*z, z^2, z^3 ],
+>       [ z, z^7, z^6, z^2, z^3, z^5, z^0, z^0 ],
+>       [ z^6, z^5, z^5, z^2, z^0, z^3, z^7, z^0 ],
+>       [ z^6, z^3, z^0, z^0, z^4, z^5, z^6, z^2 ],
+>       [ z^3, 0*z, z^2, z^3, z^5, 0*z, z^4, z ],
+>       [ z^3, z^5, z^0, z^0, z, z^7, z^6, z^2 ] ],
+>   [ [ z^5, z^6, z^3, z^5, z^5, z^6, z^3, z^5 ],
+>       [ z^3, z^3, z, 0*z, z^7, z^7, z^5, 0*z ],
+>       [ z^3, z^4, 0*z, z^5, z^3, z^4, 0*z, z^5 ],
+>       [ z^0, z^2, z, z^3, z^4, z^6, z^5, z^7 ],
+>       [ z, z^6, z^7, z^5, z^5, z^2, z^3, z ],
+>       [ z^7, z^3, z^5, 0*z, z^7, z^3, z^5, 0*z ],
+>       [ z^7, z^4, 0*z, z^5, z^3, z^0, 0*z, z ],
+>       [ z^4, z^2, z^5, z^3, z^4, z^2, z^5, z^3 ] ] ];;
+gap> g := Group(gens);;
+gap> i := 13;; Reset(GlobalMersenneTwister, i);; Reset(GlobalRandomSource, i);;
+gap> ri := RecogniseGroup(g);;
+gap> IsReady(ri);
+true
+
+# Generic projective image verification must also accept representatives that
+# differ by scalars after rewriting over a bigger field.
+# See https://github.com/gap-packages/recog/issues/33
+gap> i := 123;; Reset(GlobalMersenneTwister, i);; Reset(GlobalRandomSource, i);;
+gap> ri := RecognizeGroup(ClassicalMaximals("L",4,3)[7]);;
 gap> IsReady(ri);
 true
 


### PR DESCRIPTION
This function is used by the `ProjDeterminant` recognition method to compute images, and it was not handling the case were a given element was scaled by an element of an extension field of what it expected.

Also refine tensor docs (text fully written by Codex).

Fixes #33
Fixes #302

Co-authored-by: Codex <codex@openai.com>