### PR TITLE
Fix projective TrivialGroup lifting

### DIFF
--- a/gap/generic/TrivialGroup.gi
+++ b/gap/generic/TrivialGroup.gi
@@ -20,6 +20,12 @@ SLPforElementFuncsGeneric.TrivialGroup := function(ri,g)
     fi;
     return StraightLineProgramNC( [ [1,0] ], 1 );
 end;
+SLPforElementFuncsProjective.TrivialGroup := function(ri,g)
+    if not ri!.isone(g) then
+        return fail;
+    fi;
+    return StraightLineProgramNC( [ [1,1] ], 1 );
+end;
 #! @EndCode
 
 #! @BeginChunk TrivialGroup
@@ -50,12 +56,21 @@ function(ri)
   # size of the group
   SetSize(ri, 1);
 
-  # explained below
-  Setslpforelement(ri, SLPforElementFuncsGeneric.TrivialGroup);
+  if IsBound(ri!.projective) and ri!.projective then
+    # For projective groups we use one actual input scalar as the leaf's nice
+    # generator, instead of the identity word, so parent nodes can lift words
+    # back through the image without losing the scalar representative.
+    Setslpforelement(ri, SLPforElementFuncsProjective.TrivialGroup);
+    Setslptonice(ri, StraightLineProgramNC([[[1,1]]],
+                     Length(gens)));
+  else
+    # explained below
+    Setslpforelement(ri, SLPforElementFuncsGeneric.TrivialGroup);
 
-  # SLP from given generators to nice generators
-  Setslptonice(ri, StraightLineProgramNC([[[1,0]]],
-                   Length(gens)));
+    # SLP from given generators to nice generators
+    Setslptonice(ri, StraightLineProgramNC([[[1,0]]],
+                     Length(gens)));
+  fi;
 
   # We have reached a leaf node.
   SetFilterObj(ri, IsLeaf);

--- a/tst/working/quick/bugfix.tst
+++ b/tst/working/quick/bugfix.tst
@@ -92,6 +92,14 @@ gap> ri:=RecognizeGroup(SO(+1,4,3));;
 gap> IsReady(ri);
 true
 
+# Issue #392: a projective TrivialGroup leaf must keep a scalar representative
+# so parent nodes can lift words back through the image.
+gap> i := 228;; Reset(GlobalMersenneTwister, i);; Reset(GlobalRandomSource, i);;
+gap> G := Group([ [ 0*Z(3), Z(3)^0 ], [ Z(3), 0*Z(3) ] ]);;
+gap> ri := RecognizeGroup(G);;
+gap> IsReady(ri);
+true
+
 #
 gap> SetInfoLevel(InfoRecog, oldInfoLevel);
 gap> STOP_TEST("bugfix.tst");


### PR DESCRIPTION
For projective groups we use one actual input scalar as the leaf's
nice generator, instead of the identity word, so parent nodes can
lift words back through the image without losing the scalar
representative.

Fixes #392.

Co-authored-by: Codex <codex@openai.com>
