### PR TITLE
Handle CopySubVector rows over larger fields

### DIFF
--- a/gap/matrix/blocks.gi
+++ b/gap/matrix/blocks.gi
@@ -545,7 +545,7 @@ RECOG.ExtractLowStuff := function(m,layer,blocks,lens,basisOfFieldExtension)
       what := blocks[block[2]];
       for k in blocks[block[1]] do
           where := [pos+1..pos+Length(what)];
-          CopySubVector(m[k],v,what,where);
+          RECOG.CopySubVectorCompat(m[k],v,what,where);
           pos := pos + Length(what);
       od;
   od;

--- a/gap/projective/sl.gi
+++ b/gap/projective/sl.gi
@@ -607,7 +607,7 @@ RECOG.SLn_UpStep := function(w)
       # Clean out the first n entries to go to the fixed space of SL_n:
       zerovec := Zero(newpart[1]);
       for i in [1..w.n-1] do
-          CopySubVector(zerovec,newpart[i],[1..w.n],[1..w.n]);
+          RECOG.CopySubVectorCompat(zerovec,newpart[i],[1..w.n],[1..w.n]);
       od;
       MB := MutableBasis(w.f,[],zerovec);
       i := 1;

--- a/gap/utils.gi
+++ b/gap/utils.gi
@@ -130,3 +130,11 @@ RECOG.CachePrimesUpTo := function(n)
     RECOG.PrimesCacheUpperBound := n;
 end;
 
+RECOG.CopySubVectorCompat := function(src, dst, from, to)
+    if IsVectorObj(src) and IsVectorObj(dst) then
+        CopySubVector(src, dst, from, to);
+    else
+        dst{to} := src{from};
+    fi;
+    return dst;
+end;

--- a/tst/working/quick/bugfix.tst
+++ b/tst/working/quick/bugfix.tst
@@ -54,6 +54,12 @@ gap> RecogniseGroup(SL(2,5));
     F:<recognition node Scalar Dim=1 Field=5>
     K:<trivial kernel>>
 
+# Issue #66: direct products over larger fields must not rely on
+# CopySubVector only handling IsVectorObj rows.
+gap> ri := RecognizeGroup(DirectProduct(SU(3,17), SL(3,17)));;
+gap> IsReady(ri);
+true
+
 # We had a bug where RECOG.IsScalarMat was used incorrectly (return value was
 # assumed to be true or false, but could be an FFE). This example used to
 # trigger the error, which looked like this:


### PR DESCRIPTION
Add a small compatibility helper that falls back to slice
assignment when CopySubVector cannot handle non-IsVectorObj rows
over larger fields. Use it in the matrix block extractor and the
projective SL basis rewrite

Fixes #66

Co-authored-by: Codex <codex@openai.com>
