### PR TITLE
Enable immediate verification for NotAbsolutelyIrred

### DIFF
--- a/gap/generic/TrivialGroup.gi
+++ b/gap/generic/TrivialGroup.gi
@@ -20,12 +20,6 @@ SLPforElementFuncsGeneric.TrivialGroup := function(ri,g)
     fi;
     return StraightLineProgramNC( [ [1,0] ], 1 );
 end;
-SLPforElementFuncsProjective.TrivialGroup := function(ri,g)
-    if not ri!.isone(g) then
-        return fail;
-    fi;
-    return StraightLineProgramNC( [ [1,1] ], 1 );
-end;
 #! @EndCode
 
 #! @BeginChunk TrivialGroup
@@ -56,21 +50,12 @@ function(ri)
   # size of the group
   SetSize(ri, 1);
 
-  if IsBound(ri!.projective) and ri!.projective then
-    # For projective groups we use one actual input scalar as the leaf's nice
-    # generator, instead of the identity word, so parent nodes can lift words
-    # back through the image without losing the scalar representative.
-    Setslpforelement(ri, SLPforElementFuncsProjective.TrivialGroup);
-    Setslptonice(ri, StraightLineProgramNC([[[1,1]]],
-                     Length(gens)));
-  else
-    # explained below
-    Setslpforelement(ri, SLPforElementFuncsGeneric.TrivialGroup);
+  # explained below
+  Setslpforelement(ri, SLPforElementFuncsGeneric.TrivialGroup);
 
-    # SLP from given generators to nice generators
-    Setslptonice(ri, StraightLineProgramNC([[[1,0]]],
-                     Length(gens)));
-  fi;
+  # SLP from given generators to nice generators
+  Setslptonice(ri, StraightLineProgramNC([[[1,0]]],
+                   Length(gens)));
 
   # We have reached a leaf node.
   SetFilterObj(ri, IsLeaf);

--- a/gap/projective/c3c5.gi
+++ b/gap/projective/c3c5.gi
@@ -246,6 +246,7 @@ function(ri)
   # Also, doing normal closure will not help!
   findgensNmeth(ri).method := FindKernelRandom;
   findgensNmeth(ri).args := [5];
+  Setimmediateverification(ri, true);
   AddMethod(InitialDataForKernelRecogNode(ri).hints,
             FindHomMethodsProjective.BiggerScalarsOnly,
             2000);

--- a/tst/working/quick/bugfix.tst
+++ b/tst/working/quick/bugfix.tst
@@ -191,6 +191,21 @@ gap> Size(ri);
 gap> ForAll(GeneratorsOfGroup(G), x -> SLPforElement(ri, x) <> fail);
 true
 
+# Issue #392: a projective TrivialGroup leaf must keep a scalar representative
+# so parent nodes can lift words back through the image.
+gap> i := 228;; Reset(GlobalMersenneTwister, i);; Reset(GlobalRandomSource, i);;
+gap> G := Group([ [ 0*Z(3), Z(3)^0 ], [ Z(3), 0*Z(3) ] ]);;
+gap> ri := RecognizeGroup(G);;
+gap> IsReady(ri);
+true
+
+# Issue #423: return of issue #392 with different setup
+gap> i := 1226;; Reset(GlobalMersenneTwister, i);; Reset(GlobalRandomSource, i);;
+gap> G := Group([ [ 0*Z(3), Z(3)^0 ], [ Z(3), 0*Z(3) ] ]);;
+gap> ri := RecognizeGroup(G);;
+gap> IsReady(ri);
+true
+
 #
 gap> SetInfoLevel(InfoRecog, oldInfoLevel);
 gap> STOP_TEST("bugfix.tst");


### PR DESCRIPTION
... and revert "Fix projective TrivialGroup lifting (#412)"
aka commit 262dace2e5a0ac0266bbf365f45dcd29b6f28abb.

Fixes #423

Co-authored-by: Codex <codex@openai.com>
