### PR TITLE
Handle inconsistent C3C5 witnesses gracefully

### DIFF
--- a/gap/projective/c3c5.gi
+++ b/gap/projective/c3c5.gi
@@ -728,7 +728,10 @@ function(ri)
           fi;
           Info(InfoRecog, 2, "Restriction to H is homogeneous.");
           if not MTX.IsAbsolutelyIrreducible(collf[1][1]) then
-              ErrorNoReturn("Is this really possible? G acts absolutely irred!");
+              # This random normalizer witness is  inconsistent, so C3C5 gives up for now.
+              Info(InfoRecog, 1, "C3C5 found a homogeneous restriction whose ",
+                                 "factor is not absolutely irreducible.");
+              return TemporaryFailure;
           fi;
           homs := MTX.Homomorphisms(collf[1][1],m);
           basis := Concatenation(homs);

--- a/tst/working/quick/bugfix.tst
+++ b/tst/working/quick/bugfix.tst
@@ -212,6 +212,14 @@ gap> ri := RecognizeGroup(G);;
 gap> IsReady(ri);
 true
 
+# Issue #417: a contradictory homogeneous C3/C5 witness for SO(+1,4,3)
+# must not raise an internal error.
+# See https://github.com/gap-packages/recog/issues/417
+gap> i := 138;; Reset(GlobalMersenneTwister, 1);; Reset(GlobalRandomSource, i);;
+gap> ri := RecognizeGroup(SO(+1,4,3));;
+gap> IsReady(ri);
+true
+
 #
 gap> SetInfoLevel(InfoRecog, oldInfoLevel);
 gap> STOP_TEST("bugfix.tst");


### PR DESCRIPTION
Fixes #417.

Co-authored-by: Codex <codex@openai.com>
