### PR TITLE
Fix determinant normalization in ClassicalNatural

### DIFF
--- a/gap/projective/classicalnatural.gi
+++ b/gap/projective/classicalnatural.gi
@@ -800,31 +800,6 @@ RECOG.SetupNormalisationListForPSLd := function(f,d)
   return list;
 end;
 
-# el: a field element
-# d: a positive integer (typically ri!.gcd.gcd)
-# f: a galois field (typically ri!.field)
-#
-# Compute a primitive d-th root of el in the field f.
-# TODO: This function copies the code from RootFFE, which will
-# appear in GAP 4.9. Once GAP 4.9 is out, we can switch
-# to using RootFFE directly.
-RECOG.ComputeRootInFiniteField := function(el, d, f)
-    local z, e, m, p, a;
-    if IsZero(el) or IsOne(el)  then
-        return el;
-    fi;
-    z := PrimitiveRoot(f);
-    m := Size(f) - 1;
-    e := LogFFE(el, z);
-    p := GcdInt(m, e);
-    d := d mod m;
-    a := GcdInt(m, d);
-    if p mod a <> 0  then
-        return fail;
-    fi;
-    a := e * (a / d mod (m / p)) / a mod m;
-    return z ^ a;
-end;
 
 # Express an element of PSL_d as an slp in terms of standard generators.
 SLPforElementFuncsProjective.PSLd := function(ri,x)
@@ -842,7 +817,7 @@ SLPforElementFuncsProjective.PSLd := function(ri,x)
       # We thus can compute a d-th root of 1/det, and scale y with it,
       # in order to obtain a matrix with determinant 1 in the same
       # projective class.
-      root := RECOG.ComputeRootInFiniteField(1/det,Length(y),ri!.field);
+      root := RootFFE(ri!.field,1/det,Length(y));
       if root = fail then
           return fail;
       fi;
@@ -897,13 +872,7 @@ function(ri)
   for i in [1..Length(gens)] do
       det := DeterminantMat(gens[i]);
       if not IsOne(det) then
-          # If gcd(d, q-1) = 1 and d=2, det^-1 is a square in f.
-          # Thus use root s.t. root^2 = det^-1, so that det * root^2 = 1.
-          if gcd.gcd = 1 and d = 2 then
-              root := RECOG.ComputeRootInFiniteField(det^-1, 2, f);
-          else
-              root := RECOG.ComputeRootInFiniteField(det, gcd.gcd, f);
-          fi;
+          root := RootFFE(f, det^-1, d);
           if root = fail then
               ErrorNoReturn("Should not have happened, 15634, tell Max!");
           fi;

--- a/gap/projective/classicalnatural.gi
+++ b/gap/projective/classicalnatural.gi
@@ -897,7 +897,13 @@ function(ri)
   for i in [1..Length(gens)] do
       det := DeterminantMat(gens[i]);
       if not IsOne(det) then
-          root := RECOG.ComputeRootInFiniteField(det,gcd.gcd,f);
+          # If gcd(d, q-1) = 1 and d=2, det^-1 is a square in f.
+          # Thus use root s.t. root^2 = det^-1, so that det * root^2 = 1.
+          if gcd.gcd = 1 and d = 2 then
+              root := RECOG.ComputeRootInFiniteField(det^-1, 2, f);
+          else
+              root := RECOG.ComputeRootInFiniteField(det, gcd.gcd, f);
+          fi;
           if root = fail then
               ErrorNoReturn("Should not have happened, 15634, tell Max!");
           fi;

--- a/tst/working/veryslow/ClassicalNatural.tst
+++ b/tst/working/veryslow/ClassicalNatural.tst
@@ -104,7 +104,8 @@ gap> TestRecogGL(19,5);;
 Stamp: ClassicalNatural
 
 #
-gap> #TestRecogGL(2,8);; # FIXME: see issue #12
+gap> TestRecogGL(2,8);;
+Stamp: ClassicalNatural
 gap> TestRecogGL(3,8);;
 Stamp: ClassicalNatural
 gap> TestRecogGL(4,8);;
@@ -154,7 +155,8 @@ Stamp: ClassicalNatural
 gap> #TestRecogGL(19,9);; # disabled to speedup this .tst file
 
 #
-gap> #TestRecogGL(2,16);; # FIXME: see issue #12
+gap> TestRecogGL(2,16);;
+Stamp: ClassicalNatural
 gap> TestRecogGL(3,16);;
 Stamp: ClassicalNatural
 gap> TestRecogGL(4,16);;


### PR DESCRIPTION
When `a := gcd(d, q-1) = 1` and `d = 2`, scaling a 2x2 matrix by `root` changes the determinant by `root^2`. The previous code computed a `a`-th `root` of `det`, which is incorrect in this case.
Fix: when `a = 1 and d = 2`, compute `root` s.t. `root^2 = det^-1`.

Fixes #12.
