### PR TITLE
Add std presentation for LowerLeftPGroup

### DIFF
--- a/gap/base/recognition.gi
+++ b/gap/base/recognition.gi
@@ -852,13 +852,13 @@ InstallGlobalFunction( CalcStdPresentationGeneric,
     # Natural homomorphisms from/to the free groups.
     # Note: embFrFac*epiTot maps generator of frFrac to
     # the chosen preimage in pregensfac(ri)
-    epiTot := GroupHomomorphismByImages(
+    epiTot := GroupHomomorphismByImagesNC(
         frTot, Grp(ri), frTotGens, NiceGens(ri)
     );
-    embFrFac := GroupHomomorphismByImages(
+    embFrFac := GroupHomomorphismByImagesNC(
         frFac, frTot, frFacGens, frTotGens{[1..rankFac]}
     );
-    embFrKer := GroupHomomorphismByImages(
+    embFrKer := GroupHomomorphismByImagesNC(
         frKer, frTot, frKerGens, frTotGens{[rankFac+1..rankFac+rankKer]}
     );
 

--- a/gap/matrix/blocks.gi
+++ b/gap/matrix/blocks.gi
@@ -759,6 +759,39 @@ SLPforElementFuncsMatrix.LowerLeftPGroup := function(ri,g)
   return StraightLineProgramNC([l], Length(ri!.gensNvectors));
 end;
 
+BindGlobal("CalcStdPresentationLowerLeftPGroup",
+function(ri)
+  local f, fgens, i, ng, p, rels, rhs, slp, rank, pres, j;
+
+  ng := NiceGens(ri);
+  rank := Length(ng);
+  f := FreeGroup(rank);
+  fgens := GeneratorsOfGroup(f);
+  p := Characteristic(ri!.field);
+  rels := [];
+
+  for i in [1..rank] do
+      slp := SLPforElement(ri, ng[i]^p);
+      if slp = fail then
+          ErrorNoReturn("LowerLeftPGroup power relation rewrite failed");
+      fi;
+      rhs := ResultOfStraightLineProgram(slp, fgens);
+      Add(rels, fgens[i]^p * rhs^-1);
+
+      for j in [1..i-1] do
+          slp := SLPforElement(ri, ng[i]^ng[j]);
+          if slp = fail then
+              ErrorNoReturn("LowerLeftPGroup conjugation rewrite failed");
+          fi;
+          rhs := ResultOfStraightLineProgram(slp, fgens);
+          Add(rels, (fgens[i]^fgens[j]) * rhs^-1);
+      od;
+  od;
+
+  pres := f / rels;
+  SetStdPresentation(ri, pres);
+end);
+
 #! @BeginChunk LowerLeftPGroup
 #! This method is only called by a hint from <Ref Subsect="BlockLowerTriangular" Style="Text"/>
 #! as the kernel of the homomorphism mapping to the diagonal blocks.
@@ -788,6 +821,7 @@ function(ri)
   p := Characteristic(f);
   SetFilterObj(ri,IsLeaf);
   Setslpforelement(ri,SLPforElementFuncsMatrix.LowerLeftPGroup);
+  SetCalcStdPresentation(ri, CalcStdPresentationLowerLeftPGroup);
   SetSize(ri,p^Length(ri!.gensNvectors));
   return Success;
 end);

--- a/tst/working/quick/presentation.tst
+++ b/tst/working/quick/presentation.tst
@@ -39,6 +39,29 @@ gap> smallMatGroups := Concatenation([
 > ]);;
 gap> largeMatGroups := [SL(4,3), Sp(4,7), SO(5,3)];;
 gap> permGroups := [SymmetricGroup(5), AlternatingGroup(7)];;
+
+# LowerLeftPGroup leaves should expose a pc presentation with one power
+# relation per generator and one conjugation relation per pair.
+gap> gens := [];;
+gap> for i in [2..3] do
+>   m := IdentityMat(3, GF(2));;
+>   m[i,i-1] := One(GF(2));;
+>   Add(gens, m);
+> od;
+gap> ri := RecognizeGroup(Group(gens));;
+gap> Size(ri);
+8
+gap> Size(StdPresentation(ri));
+8
+gap> leaf := GetCompositionTreeNode(ri, "fk");;
+gap> std := StdPresentation(leaf);;
+gap> Size(std);
+8
+gap> RelatorsOfFpGroup(StdPresentation(leaf));
+[ f1^2, f2^2, f1^-1*f2*f1*f3^-1*f2^-1, f3^2, f1^-1*f3*f1*f3^-1, 
+  f2^-1*f3*f2*f3^-1 ]
+
+#
 gap> for G in smallMatGroups do testPres(G, true, false); od;
 gap> for G in largeMatGroups do testPres(G, false, false); od;
 gap> for G in smallMatGroups do testPres(G, true, true); od;


### PR DESCRIPTION
This exploits that the nice generators in this case form a pcgs, and we have efficient methods to work with these.

This does *not* compute a pc group, to fit in the general framework, but perhaps we should add that at some point?

Also speed up CalcStdPresentationGeneric substantially by using GroupHomomorphismByImagesNC (otherwise it ends up trying to do a membership test for the range, which of course we can't do in general for our larger groups).

Co-authored-by: Codex <codex@openai.com>

---

Follow-up to PR #441; motivated by issue #343 (but of course we want something like this anyway.