### PR TITLE
Fix C6 block kernel handling

### DIFF
--- a/gap/matrix/matimpr.gi
+++ b/gap/matrix/matimpr.gi
@@ -224,8 +224,22 @@ function(ri)
   InitialDataForImageRecogNode(ri).blocks := blocks;
   AddMethod(InitialDataForImageRecogNode(ri).hints, FindHomMethodsProjective.BlocksModScalars, 2000);
   # For the kernel:
+  # The scalar-block kernel is abelian, so random kernel sampling is enough
+  # and avoids under-generating it via the default normal-closure path.
+  findgensNmeth(ri).method := FindKernelRandom;
+  findgensNmeth(ri).args := [Length(blocks)+10];
+  if ri!.blocksize = 1 then
+      # BlocksModScalars is trivial in this case, so the whole group is the
+      # kernel that must be passed on to BlocksBackToMats.
+      findgensNmeth(ri).method := function(ri)
+        SetgensN(ri, ShallowCopy(ri!.gensHmem));
+        return true;
+      end;
+      findgensNmeth(ri).args := [];
+  fi;
   InitialDataForKernelRecogNode(ri).blocks := blocks;
   AddMethod(InitialDataForKernelRecogNode(ri).hints, FindHomMethodsProjective.BlocksBackToMats, 2000);
+  Setimmediateverification(ri, true);
   return Success;
 end);
 

--- a/tst/working/quick/bugfix.tst
+++ b/tst/working/quick/bugfix.tst
@@ -291,6 +291,60 @@ gap> Size(ri);
 gap> ForAll(GeneratorsOfGroup(H), x -> SLPforElement(ri, x) <> fail);
 true
 
+# Issue #444: a projective C6 block kernel must keep the full scalar-block
+# size when passing through DoBaseChangeForBlocks and BlocksBackToMats.
+# See https://github.com/gap-packages/recog/issues/444
+gap> i := 1;; Reset(GlobalMersenneTwister, i);; Reset(GlobalRandomSource, i);;
+gap> m := ClassicalMaximals("L",8,7);;
+gap> g := m[10];;
+gap> re := RECOG.New2RecogniseC6(g);;
+gap> hom := GroupHomByFuncWithData(g, GroupWithGenerators(re.igens),
+>   RECOG.HomFuncActionOnBlocks,
+>   rec(r := re.r, n := re.n, q := re.q, blks := re.basis.blocks));;
+gap> k := KernelOfMultiplicativeGeneralMapping(hom);;
+gap> data := rec(hints := []);;
+gap> data.t := re.basis.blocks.blocks;;
+gap> data.blocksize := 8 / re.basis.blocks.ell;;
+gap> AddMethod(data.hints, FindHomMethodsProjective.DoBaseChangeForBlocks, 2000);;
+gap> ri := RecogniseGeneric(k, FindHomDbProjective, "", data);;
+gap> IsReady(ri);
+true
+gap> h := Group(List(GeneratorsOfGroup(k), RECOG.HomBackToMats));;
+gap> Size(h);
+139968
+gap> Size(ri);
+139968
+
+# Issue #471: projective Blocks below the C6 path must collect enough
+# scalar-block kernel generators for the final SLP coverage check.
+# See https://github.com/gap-packages/recog/issues/471
+gap> i := 21;; Reset(GlobalMersenneTwister, i);; Reset(GlobalRandomSource, i);;
+gap> G:=Group(Z(5)^0 * [
+> [ [ 0,0,1,0,0,0,0,0 ], [ 0,1,0,0,0,0,0,0 ], [ 0,0,0,0,1,0,0,0 ],
+>     [ 0,0,0,0,0,0,0,1 ], [ 1,0,0,0,0,0,0,0 ], [ 0,0,0,1,0,0,0,0 ],
+>     [ 0,0,0,0,0,0,1,0 ], [ 0,0,0,0,0,1,0,0 ] ],
+>   [ [ 1,0,0,0,0,0,0,0 ], [ 0,0,0,0,0,1,0,0 ], [ 0,0,0,0,1,0,0,0 ],
+>     [ 0,1,0,0,0,0,0,0 ], [ 0,0,0,0,0,0,1,0 ], [ 0,0,0,1,0,0,0,0 ],
+>     [ 0,0,1,0,0,0,0,0 ], [ 0,0,0,0,0,0,0,1 ] ],
+>   [ [ 0,0,1,0,0,0,0,0 ], [ 0,1,0,0,0,0,0,0 ], [ 1,0,0,0,0,0,0,0 ],
+>     [ 0,0,0,1,0,0,0,0 ], [ 0,0,0,0,1,0,0,0 ], [ 0,0,0,0,0,0,0,1 ],
+>     [ 0,0,0,0,0,0,1,0 ], [ 0,0,0,0,0,1,0,0 ] ],
+>   [ [ 0,0,0,0,0,0,0,1 ], [ 0,1,0,0,0,0,0,0 ], [ 0,0,0,0,0,1,0,0 ],
+>     [ 0,0,0,1,0,0,0,0 ], [ 0,0,0,0,1,0,0,0 ], [ 0,0,1,0,0,0,0,0 ],
+>     [ 0,0,0,0,0,0,1,0 ], [ 1,0,0,0,0,0,0,0 ] ],
+>   [ [ 4,0,0,0,0,0,0,0 ], [ 0,1,0,0,0,0,0,0 ], [ 0,0,1,0,0,0,0,0 ],
+>     [ 0,0,0,1,0,0,0,0 ], [ 0,0,0,0,1,0,0,0 ], [ 0,0,0,0,0,1,0,0 ],
+>     [ 0,0,0,0,0,0,1,0 ], [ 0,0,0,0,0,0,0,4 ] ],
+>   [ [ 3,0,0,0,0,0,0,0 ], [ 0,1,0,0,0,0,0,0 ], [ 0,0,2,0,0,0,0,0 ],
+>     [ 0,0,0,1,0,0,0,0 ], [ 0,0,0,0,1,0,0,0 ], [ 0,0,0,0,0,3,0,0 ],
+>     [ 0,0,0,0,0,0,1,0 ], [ 0,0,0,0,0,0,0,2 ] ]
+> ]);;
+gap> ri := RecognizeGroup(G);;
+gap> IsReady(ri);
+true
+gap> ForAll(GeneratorsOfGroup(G), x -> SLPforElement(ri, x) <> fail);
+true
+
 # Issue #450: a D247 tensor witness contradicted by a tensor-factor swap
 # must not raise an internal error.
 # See https://github.com/gap-packages/recog/issues/450


### PR DESCRIPTION
When Blocks sees blocksize 1, BlocksModScalars is trivial. Pass the whole group to BlocksBackToMats in that case.

Co-authored-by: Codex <codex@openai.com>

Resolves #444.

UPDATE: modified, now also fixes #471.