### PR TITLE
Stabilize isNotExt for orthogonal naming

### DIFF
--- a/gap/matrix/classical.gi
+++ b/gap/matrix/classical.gi
@@ -379,6 +379,9 @@ function(recognise)
         elif d mod 4 = 0 and q mod 2 = 0 then
              recognise.isNotExt := ForAny(E, x -> x mod 4 = 2);
         elif d mod 4 = 0 and q mod 2 = 1 then
+             if Length(E) < 2 then
+                 return TemporaryFailure;
+             fi;
              recognise.isNotExt := differmodfour(E);
         elif d mod 4 = 2 and q mod 2 = 0 then
             recognise.isNotExt := (Length(E) > 0);
@@ -393,6 +396,12 @@ function(recognise)
         if d mod 4 = 2 then
             recognise.isNotExt := ForAny(E, x -> x mod 4 = 0);
         elif d mod 4 = 0 then
+            # With only one observed ppd exponent there is no mod 4
+            # discrepancy yet, so we cannot conclude that the extension-field
+            # case is still possible.
+            if Length(E) < 2 then
+                return TemporaryFailure;
+            fi;
             recognise.isNotExt := differmodfour(E);
         else
            Info( InfoClassical, 2, "d cannot be odd in hint O+");
@@ -406,6 +415,9 @@ function(recognise)
         if d mod 4 = 0 then
             recognise.isNotExt := ForAny(E, x -> x mod 4 = 2);
         elif d mod 4 = 2 then
+            if Length(E) < 2 then
+                return TemporaryFailure;
+            fi;
             recognise.isNotExt := differmodfour(E);
         else
            Info( InfoClassical, 2, "d cannot be odd in hint O-");

--- a/tst/working/combined/ClassicalNaturalNaming.tst
+++ b/tst/working/combined/ClassicalNaturalNaming.tst
@@ -24,20 +24,10 @@ gap> d:=5;; for q in [2, 3, 4, 5, 7, 8, 9, 11, 13] do TestNaming("SL", d, q); od
 gap> d:=3;; for q in [2, 3] do TestNaming("SO", d, q); od;
 #@fi
 
-# FIXME/TODO: SO(3,9) has bad value for isOmegaContained; expected true, got unknown
-# FIXME/TODO: sometimes get SO(3,11) has bad value for isOmegaContained; expected true, got unknown
-# FIXME/TODO: sometimes get SO(5,3) has bad value for isOmegaContained; expected true, got unknown
-# FIXME/TODO: sometimes get SO(7,3) has bad value for isOmegaContained; expected true, got unknown
-#@if IsBound(RECOG_TEST_SUITE) and RECOG_TEST_SUITE = "broken"
-gap> TestNaming("SO", 3, 9);
-gap> TestNaming("SO", 3, 11);
-gap> TestNaming("SO", 5, 3);
-gap> TestNaming("SO", 7, 3);
-#@fi
 #@if not IsBound(RECOG_TEST_SUITE) or RECOG_TEST_SUITE = "slow"
-gap> d:=3;; for q in [4, 5, 7, 8, 13] do TestNaming("SO", d, q); od;
-gap> d:=5;; for q in [2, 4, 5, 7, 8, 9, 11, 13] do TestNaming("SO", d, q); od;
-gap> d:=7;; for q in [2, 4, 5, 7, 8, 9, 11, 13] do TestNaming("SO", d, q); od;
+gap> d:=3;; for q in [2, 3, 4, 5, 7, 8, 9, 11, 13] do TestNaming("SO", d, q); od;
+gap> d:=5;; for q in [2, 3, 4, 5, 7, 8, 9, 11, 13] do TestNaming("SO", d, q); od;
+gap> d:=7;; for q in [2, 3, 4, 5, 7, 8, 9, 11, 13] do TestNaming("SO", d, q); od;
 #@fi
 
 #
@@ -49,18 +39,12 @@ gap> d:=7;; for q in [2, 4, 5, 7, 8, 9, 11, 13] do TestNaming("SO", d, q); od;
 gap> d:=4;; for q in [2, 3] do TestNaming("SO", +1, d, q); od;
 #@fi
 
-# FIXME/TODO: sometimes get "SO(1,d,q) has bad value for isOmegaContained;
-#    expected true, got unknown" for
-#    (d,q) in [ (4,11), (4,13), (8,4), (8,7), (8,8) ]
-# FIXME/TODO: for SO(+1,8,5) sometimes get warnings of the form '#I  Have 38255 points'
-#@if IsBound(RECOG_TEST_SUITE) and RECOG_TEST_SUITE = "broken"
-gap> d:=4;; for q in [11, 13] do TestNaming("SO", +1, d, q); od;
-gap> d:=8;; for q in [4, 5, 7, 8 do TestNaming("SO", +1, d, q); od;
-#@fi
 #@if not IsBound(RECOG_TEST_SUITE) or RECOG_TEST_SUITE = "slow"
-gap> d:=4;; for q in [4, 5, 7, 8, 9] do TestNaming("SO", +1, d, q); od;
+gap> d:=4;; for q in [2, 3, 4, 5, 7, 8, 9, 11, 13] do TestNaming("SO", +1, d, q); od;
 gap> d:=6;; for q in [2, 3, 4, 5, 7, 8, 9, 11, 13] do TestNaming("SO", +1, d, q); od;
-gap> d:=8;; for q in [2, 3, 9, 11, 13] do TestNaming("SO", +1, d, q); od;
+gap> d:=8;; for q in [2, 3, 4, 5, 7, 8, 9, 11, 13] do TestNaming("SO", +1, d, q); od;
+gap> d:=10;; for q in [2, 3, 4, 5] do TestNaming("SO", +1, d, q); od;
+gap> d:=12;; for q in [2, 3, 4, 5] do TestNaming("SO", +1, d, q); od;
 #@fi
 
 #
@@ -70,14 +54,9 @@ gap> d:=8;; for q in [2, 3, 9, 11, 13] do TestNaming("SO", +1, d, q); od;
 gap> d:=4;; for q in [2, 3] do TestNaming("SO", -1, d, q); od;
 #@fi
 
-# FIXME/TODO: sometimes get SO(-1,6,2) has bad value for isOmegaContained; expected true, got unknown
-# FIXME/TODO: sometimes get SO(-1,6,3) has bad value for isOmegaContained; expected true, got unknown
-#@if IsBound(RECOG_TEST_SUITE) and RECOG_TEST_SUITE = "broken"
-gap> d:=6;; for q in [2, 3] do TestNaming("SO", -1, d, q); od;
-#@fi
 #@if not IsBound(RECOG_TEST_SUITE) or RECOG_TEST_SUITE = "slow"
-gap> d:=4;; for q in [4, 5, 7, 8, 9, 11, 13] do TestNaming("SO", -1, d, q); od;
-gap> d:=6;; for q in [4, 5, 7, 8, 9, 11, 13] do TestNaming("SO", -1, d, q); od;
+gap> d:=4;; for q in [2, 3, 4, 5, 7, 8, 9, 11, 13] do TestNaming("SO", -1, d, q); od;
+gap> d:=6;; for q in [2, 3, 4, 5, 7, 8, 9, 11, 13] do TestNaming("SO", -1, d, q); od;
 gap> d:=8;; for q in [2, 3, 4, 5, 7, 8, 9, 11, 13] do TestNaming("SO", -1, d, q); od;
 #@fi
 
@@ -89,13 +68,9 @@ gap> d:=8;; for q in [2, 3, 4, 5, 7, 8, 9, 11, 13] do TestNaming("SO", -1, d, q)
 gap> d:=4;; for q in [2, 3] do TestNaming("Sp", d, q); od;
 #@fi
 
-# FIXME/TODO: always get Sp(4,4) has bad value for isSpContained; expected true, got unknown
-# FIXME/TODO: sometimes get Sp(4,9) has bad value for isSpContained; expected true, got unknown
-# FIXME/TODO: sometimes get Sp(4,13) has bad value for isSpContained; expected true, got unknown
-# FIXME/TODO: sometimes get Sp(6,2) has bad value for isSpContained; expected true, got unknown
 #@if not IsBound(RECOG_TEST_SUITE) or RECOG_TEST_SUITE = "slow"
-gap> d:=4;; for q in [5, 7, 8, 11] do TestNaming("Sp", d, q); od;
-gap> d:=6;; for q in [3, 4, 5, 7, 8, 9, 11, 13] do TestNaming("Sp", d, q); od;
+gap> d:=4;; for q in [2, 3, 4, 5, 7, 8, 9, 11, 13] do TestNaming("Sp", d, q); od;
+gap> d:=6;; for q in [2, 3, 4, 5, 7, 8, 9, 11, 13] do TestNaming("Sp", d, q); od;
 gap> d:=8;; for q in [2, 3, 4, 5, 7, 8, 9, 11, 13] do TestNaming("Sp", d, q); od;
 #@fi
 
@@ -106,10 +81,9 @@ gap> d:=8;; for q in [2, 3, 4, 5, 7, 8, 9, 11, 13] do TestNaming("Sp", d, q); od
 gap> d:=3;; for q in [2, 3] do TestNaming("SU", d, q); od;
 #@fi
 
-# FIXME/TODO: sometimes get SU(6,2) has bad value for isSUContained; expected true, got unknown
 #@if not IsBound(RECOG_TEST_SUITE) or RECOG_TEST_SUITE = "slow"
 gap> d:=3;; for q in [2, 3, 4, 5, 7, 8, 9, 11, 13] do TestNaming("SU", d, q); od;
 gap> d:=4;; for q in [2, 3, 4, 5, 7, 8, 9, 11, 13] do TestNaming("SU", d, q); od;
 gap> d:=5;; for q in [2, 3, 4, 5, 7, 8, 9, 11, 13] do TestNaming("SU", d, q); od;
-gap> d:=6;; for q in [3, 4, 5, 7, 8, 9, 11, 13] do TestNaming("SU", d, q); od;
+gap> d:=6;; for q in [2, 3, 4, 5, 7, 8, 9, 11, 13] do TestNaming("SU", d, q); od;
 #@fi


### PR DESCRIPTION
Delay the mod 4 extension-field checks until at least two ppd exponents have been observed. A singleton `E` is incomplete evidence, and SO(+1,12,3) could otherwise record isNotExt := false in some runs.

Update `ClassicalNaturalNaming.tst` to reflect this and other recent fixes.

Co-authored-by: Codex <codex@openai.com>

Together with PR #451 and #452 it seems this fixes #379