### PR TITLE
Guard SLConstructive against bad det congruences

### DIFF
--- a/gap/matrix/slconstr.gi
+++ b/gap/matrix/slconstr.gi
@@ -1247,7 +1247,11 @@ return fail;
      det := Determinant(mat);
      if not (det = Z(q)^0) then
         gcd := Gcd(d,q-1);
-        exp := (LogFFE(det, Z(q))/gcd) / (d/gcd) mod ((q-1)/gcd);
+        i := LogFFE(det, Z(q));
+        if i mod gcd <> 0 then
+           return fail;
+        fi;
+        exp := QuoInt(i, gcd) / QuoInt(d, gcd) mod QuoInt(q-1, gcd);
         slprog := SLCR.PowerProg(data.sprog[d],exp);
         rightslp := SLCR.ProdProg(rightslp, slprog);
         W := W * ResultOfStraightLineProgram (slprog, List (data.gens, x -> x[1]));

--- a/tst/working/quick/bugfix.tst
+++ b/tst/working/quick/bugfix.tst
@@ -261,6 +261,14 @@ gap> Size(ri);
 gap> ForAll(GeneratorsOfGroup(H), x -> SLPforElement(ri, x) <> fail);
 true
 
+# Issue #313: an unsatisfied determinant congruence in SLConstructive must
+# cause recognition to back out, not raise a ModRat error.
+# See https://github.com/gap-packages/recog/issues/313
+gap> i := 58;; Reset(GlobalMersenneTwister, i);; Reset(GlobalRandomSource, i);;
+gap> ri := RecognizeGroup(ClassicalMaximals("L",4,3)[8]);;
+gap> IsReady(ri);
+true
+
 #
 gap> SetInfoLevel(InfoRecog, oldInfoLevel);
 gap> STOP_TEST("bugfix.tst");


### PR DESCRIPTION
Return fail when the determinant correction step would require
dividing by a noninvertible class modulo q - 1 instead of crashing
in ModRat.

Co-authored-by: Codex <codex@openai.com>

Fixes #313