### PR TITLE
Recognise SL2 in naming

### DIFF
--- a/gap/matrix/classical.gi
+++ b/gap/matrix/classical.gi
@@ -1136,6 +1136,27 @@ function(recognise)
     fi;
 end);
 
+BindRecogMethod("FindHomMethodsClassical", "Degree2SL",
+"tests whether a degree-2 group contains SL",
+function(recognise)
+    if recognise.d <> 2 then
+        return NeverApplicable;
+    fi;
+
+    if RECOG.IsThisSL2Natural(GeneratorsOfGroup(recognise.grp),
+                              recognise.field) then
+        recognise.isGeneric := false;
+        recognise.isReducible := false;
+        recognise.isNotExt := true;
+        recognise.isSLContained := true;
+        recognise.isSpContained := true;
+        Info(InfoClassical,2,"The group contains SL(2, ", recognise.q, ");");
+        return Success;
+    fi;
+
+    return TemporaryFailure;
+end);
+
 ## Main function to test whether group contains SL
 BindRecogMethod("FindHomMethodsClassical", "IsSLContained",
 "tests whether group contains SL",
@@ -2435,6 +2456,8 @@ AddMethod(ClassicalMethDb, FindHomMethodsClassical.NonGenericOrthogonalPlus, 13)
 AddMethod(ClassicalMethDb, FindHomMethodsClassical.NonGenericOrthogonalMinus, 14);
 
 AddMethod(ClassicalMethDb, FindHomMethodsClassical.NonGenericOrthogonalCircle, 15);
+
+AddMethod(ClassicalMethDb, FindHomMethodsClassical.Degree2SL, 16);
 
 AddMethod(ClassicalMethDb, FindHomMethodsClassical.IsSLContained, 16);
 

--- a/gap/matrix/classical.gi
+++ b/gap/matrix/classical.gi
@@ -1124,6 +1124,27 @@ function(recognise)
     fi;
 end);
 
+BindRecogMethod("FindHomMethodsClassical", "Degree2SL",
+"tests whether a degree-2 group contains SL",
+function(recognise)
+    if recognise.d <> 2 then
+        return NeverApplicable;
+    fi;
+
+    if RECOG.IsThisSL2Natural(GeneratorsOfGroup(recognise.grp),
+                              recognise.field) then
+        recognise.isGeneric := false;
+        recognise.isReducible := false;
+        recognise.isNotExt := true;
+        recognise.isSLContained := true;
+        recognise.isSpContained := true;
+        Info(InfoClassical,2,"The group contains SL(2, ", recognise.q, ");");
+        return Success;
+    fi;
+
+    return TemporaryFailure;
+end);
+
 ## Main function to test whether group contains SL
 BindRecogMethod("FindHomMethodsClassical", "IsSLContained",
 "tests whether group contains SL",
@@ -2423,6 +2444,8 @@ AddMethod(ClassicalMethDb, FindHomMethodsClassical.NonGenericOrthogonalPlus, 13)
 AddMethod(ClassicalMethDb, FindHomMethodsClassical.NonGenericOrthogonalMinus, 14);
 
 AddMethod(ClassicalMethDb, FindHomMethodsClassical.NonGenericOrthogonalCircle, 15);
+
+AddMethod(ClassicalMethDb, FindHomMethodsClassical.Degree2SL, 16);
 
 AddMethod(ClassicalMethDb, FindHomMethodsClassical.IsSLContained, 16);
 

--- a/gap/projective/classicalnatural.gi
+++ b/gap/projective/classicalnatural.gi
@@ -854,17 +854,10 @@ function(ri)
   RECOG.SetPseudoRandomStamp(g,"ClassicalNatural");
 
   # First check whether we are applicable:
-  if d = 2 then
-      if not RECOG.IsThisSL2Natural(GeneratorsOfGroup(g),f) then
-          Info(InfoRecog,2,"ClassicalNatural: Is not PSL_2.");
-          return TemporaryFailure; # FIXME: TemporaryFailure here really correct?
-      fi;
-  else
-      classical := RecogniseClassical(g);
-      if classical.isSLContained <> true then
-          Info(InfoRecog,2,"ClassicalNatural: Is not PSL.");
-          return TemporaryFailure; # FIXME: TemporaryFailure here really correct?
-      fi;
+  classical := RecogniseClassical(g);
+  if classical.isSLContained <> true then
+      Info(InfoRecog,2,"ClassicalNatural: Is not PSL.");
+      return TemporaryFailure; # FIXME: TemporaryFailure here really correct?
   fi;
 
   # Now get rid of nasty determinants:

--- a/tst/working/quick/classical.tst
+++ b/tst/working/quick/classical.tst
@@ -18,3 +18,11 @@ gap> SetX(G, G, function(g,h)
 >   return gh = false or (IsEqualProjective(gh[1], g) and IsEqualProjective(gh[2], h));
 > end);
 [ true ]
+
+# issue #345: degree-2 linear groups should still report containment of SL
+gap> ri := RecogniseClassical(SL(2,37));;
+gap> ri.isSLContained;
+true
+gap> ri := RecogniseClassical(SL(2,25));;
+gap> ri.isSLContained;
+true


### PR DESCRIPTION
Co-authored-by: Codex <codex@openai.com>

Fixes #345

But I am not sure we really want that... the method used here (`RECOG.IsThisSL2Natural`) seems to be quite different to what we do in naming otherwise.

Would be really good to discuss this one with @aniemeyer. I'll leave this PR unmerged for now.

(@Till-Eisen has recently looked a lot at constructive recognition of SL2 in natural rep and may have thoughts on this as well...)