### PR TITLE
Run An/Sn tests also in degrees 15, 20, 25 and more

### DIFF
--- a/tst/working/slow/GenericSnAnUnknownDegree.tst
+++ b/tst/working/slow/GenericSnAnUnknownDegree.tst
@@ -269,7 +269,7 @@ gap> CycleStructurePerm(img2);
 
 # FindHomMethodsGeneric.SnAnUnknownDegree
 # Sn
-gap> for d in [11 .. 14] do
+gap> for d in [11 .. 30] do
 > sets := Combinations([1 .. d], 2);;
 > SdOn2Sets := Action(SymmetricGroup(d), sets, OnSets);;
 > ri := RecogNode(SdOn2Sets);;
@@ -280,7 +280,7 @@ gap> for d in [11 .. 14] do
 > od;
 
 # An
-gap> for d in [11 .. 14] do
+gap> for d in [11 .. 30] do
 > sets := Combinations([1 .. d], 2);;
 > SdOn2Sets := Action(AlternatingGroup(d), sets, OnSets);;
 > ri := RecogNode(SdOn2Sets);;


### PR DESCRIPTION
... as e.g. `RECOG.ConstructXiSn` and `RECOG.ConstructXiAn` have special cases for degrees divisible by 5 that only trigger the first time at these degrees.