### PR TITLE
PackageInfo.g: require newer versions of our dependencies

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,7 +29,6 @@ jobs:
           - '4.15'
           - '4.14'
           - '4.13'
-          - '4.12'
 
     steps:
       - uses: actions/checkout@v6

--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -266,13 +266,13 @@ PackageDoc := rec(
 ),
 
 Dependencies := rec(
-  GAP := ">=4.12",
+  GAP := ">=4.13",
   NeededOtherPackages := [
-    ["AtlasRep", ">= 1.4.0"],
-    ["FactInt", ">= 1.5.2"],
-    ["Forms", ">= 1.2"],
-    ["genss", ">= 1.3"],
-    ["Orb", ">= 3.4"],
+    ["AtlasRep", ">= 2.1.0"],
+    ["FactInt", ">= 1.6.3"],
+    ["Forms", ">= 1.2.11"],
+    ["genss", ">= 1.6.8"],
+    ["Orb", ">= 4.9.0"],  # really should be 5.1.0 for latest bug fixes
   ],
   SuggestedOtherPackages := [],
   ExternalConditions := []


### PR DESCRIPTION
The old ones tend to have bugs or other issues, and we never test
with them. So better to up these.
