### PR TITLE
Add good `StdPresentation` for symmetric and alternating groups

### DIFF
--- a/doc/recog.bib
+++ b/doc/recog.bib
@@ -296,6 +296,21 @@ MRREVIEWER = {P. P. Pálfy},
       NOTE = {https://doi.org/10.1080/00927879508825509},
 }
 
+@book {CM80,
+    AUTHOR = {Coxeter, H. S. M. and Moser, W. O. J.},
+     TITLE = {Generators and relations for discrete groups},
+    SERIES = {Ergebnisse der Mathematik und ihrer Grenzgebiete [Results in
+              Mathematics and Related Areas]},
+    VOLUME = {14},
+   EDITION = {Fourth},
+ PUBLISHER = {Springer-Verlag, Berlin-New York},
+      YEAR = {1980},
+     PAGES = {ix+169},
+      ISBN = {3-540-09212-9},
+   MRCLASS = {20-01},
+  MRNUMBER = {562913},
+}
+
 @incollection {BNS06,
     AUTHOR = {Brooksbank, Peter and Niemeyer, Alice C. and Seress, Ákos},
      TITLE = {A reduction algorithm for matrix groups with an extraspecial

--- a/gap/base/recognition.gi
+++ b/gap/base/recognition.gi
@@ -131,7 +131,7 @@ InstallGlobalFunction( TryFindHomMethod,
     local result,ri;
     ri := RecogNode(g,projective);
     Unbind(g!.pseudorandomfunc);
-    result := method(ri,g);
+    result := method(ri);
     if result in [TemporaryFailure, NeverApplicable] then
         return result;
     else

--- a/gap/perm.gi
+++ b/gap/perm.gi
@@ -27,6 +27,11 @@
 #!
 #! If the input group moves a large point (currently, this means a point
 #! larger than 10), then this method returns <K>NeverApplicable</K>.
+#!
+#! Note that if a permutation group moves only a small number of points, but
+#! the points are large (e.g. the group acts on [100..105]), then
+#! <Ref Func="ThrowAwayFixedPoints"/> may rewrite this group to a group acting
+#! on small points, thereby making <K>MovesOnlySmallPoints</K> applicable.
 #! @EndChunk
 BindRecogMethod("FindHomMethodsPerm", "MovesOnlySmallPoints",
 "calculate a stabilizer chain if only small points are moved",

--- a/gap/perm/giant.gi
+++ b/gap/perm/giant.gi
@@ -550,11 +550,13 @@ end;
 # See Corollary 10.2.2 in [Ser03].
 # See also `DoSnAnGiantTest` in the GAP library which seems to be a
 # close variant of this code.
-# This function always returns fail if Size(mp)<=7 because there exists no prime l
-# with n/2<l<n-2 for n<=7
+# Only giants of degree at least 8 can be recognised.
 RECOG.IsGiant:=function(g,mp)
   local bound, i, p, cycles, l, x, n;
   n := Length(mp);
+  # We search a permutation in g with cycle of prime length l
+  # where n/2<l<n-2.
+  # If n<=7, no such prime exists.
   if n<=7 then
     return fail;
   fi;

--- a/gap/perm/giant.gi
+++ b/gap/perm/giant.gi
@@ -803,7 +803,7 @@ BindRecogMethod("FindHomMethodsPerm", "Giant",
 # FindHomMethodsPerm.NonTransitive; model this better?
 rec(validatesOrAlwaysValidInput := true),
 function(ri)
-    local grp,grpmem,mp,res;
+    local grp,grpmem,mp,res,F,deg;
     grp := Grp(ri);
     if not IsPermGroup(grp) then
         return NeverApplicable;
@@ -832,14 +832,45 @@ function(ri)
     Setslpforelement(ri,SLPforElementFuncsPerm.Giant);
     ri!.giantinfo := res;
     SetFilterObj(ri,IsLeaf);
+    F := FreeGroup(2); # for presentation
+    deg := Size(mp);
+    # We set the presentations of Sn and An from
+    # [CM80] "Generators and relations for discrete groups", (6.21), 6.3.
+    # They coincide with the ones in
+    # [BLN+03] "A black-box group algorithm for recognizing finite symmetric 
+    # and alternating groups, I", (2.1), (2.2), (2.3),
+    # except that one relation in (2.1) and one relation in (2.3) is incorrect.
     if res.stamp = "An" then
         SetSize(ri,Factorial(Length(mp))/2);
         SetIsRecogInfoForSimpleGroup(ri,true);
+        rels := [ F.2^(deg-2), F.1^3 ];
+        if deg mod 2 = 1 then
+            Add(rels, (F.2*F.1)^deg);
+            rels := Concatenation(
+                rels,
+                List([1..QuoInt(n-3, 2)], k -> (F.1*F.2^(-k)*F.1*F.2^k)^2)
+            );
+        else
+            Add(rels, (F.2*F.1)^(deg-1));
+            rels := Concatenation(
+                rels,
+                List([1..QuoInt(n-2, 2)], k -> (F.1^((-1)^k)*F.2^-k*F.1*F.2^k)^2)
+            );
+        fi;
     else
         SetSize(ri,Factorial(Length(mp)));
         SetIsRecogInfoForAlmostSimpleGroup(ri,true);
+        # if deg>2 then
+            # Relations on F.1=(1,2), F.2 = (1,...,deg) from [CM80, (6.21)]
+            # TODO: Is this correct for d=1, 2?
+            rels := [ F.1^2, F.2^deg, (F.1*F.2)^(deg-1), (F.1*(F.1^F.2))^3 ];
+            rels := Concatenation(
+                rels, List([2..QuoInt(deg, 2)], j -> (F.1*(F.1^(F.2^j)))^2)
+            );
+        # fi;
     fi;
     SetNiceGens(ri,StripMemory(res.gens));
+    SetStdPresentation(ri,F / rels);
     return Success;
 end);
 

--- a/gap/perm/giant.gi
+++ b/gap/perm/giant.gi
@@ -550,9 +550,14 @@ end;
 # See Corollary 10.2.2 in [Ser03].
 # See also `DoSnAnGiantTest` in the GAP library which seems to be a
 # close variant of this code.
+# This function always returns fail if Size(mp)<=7 because there exists no prime l
+# with n/2<l<n-2 for n<=7
 RECOG.IsGiant:=function(g,mp)
   local bound, i, p, cycles, l, x, n;
   n := Length(mp);
+  if n<=7 then
+    return fail;
+  fi;
   bound:=20*LogInt(n,2);
   i:=0;
   repeat
@@ -789,10 +794,14 @@ RECOG.GiantEpsilon := 1/1024;
 #! @BeginChunk Giant
 #! The method tries to determine whether the input group <A>G</A> is
 #! a giant (that is, <M>A_n</M> or <M>S_n</M> in its natural action on
-#! <M>n</M> points). The output is either a data structure <M>D</M> containing
+#! <M>n</M> points). It can only succeed for permutation groups acting on
+#! at least 8 points.
+#! The output is either a data structure <M>D</M> containing
 #! nice generators for <A>G</A> and a procedure to write an SLP for arbitrary
-#! elements of <A>G</A> from the nice generators; or <K>NeverApplicable</K> if
-#! <A>G</A> is not transitive; or <K>fail</K>, in the case that no
+#! elements of <A>G</A> from the nice generators;
+#! or <K>NeverApplicable</K> if <A>G</A> is not transitive or acts on
+#! at most 7 points; 
+#! or <K>fail</K>, in the case that no
 #! evidence was found that <A>G</A> is a giant, or evidence was found, but
 #! the construction of <M>D</M> was unsuccessful.
 #! If the method constructs <M>D</M> then the calling node becomes a leaf.
@@ -803,7 +812,7 @@ BindRecogMethod("FindHomMethodsPerm", "Giant",
 # FindHomMethodsPerm.NonTransitive; model this better?
 rec(validatesOrAlwaysValidInput := true),
 function(ri)
-    local grp,grpmem,mp,res,F,deg;
+    local grp,grpmem,mp,res,F,deg,rels;
     grp := Grp(ri);
     if not IsPermGroup(grp) then
         return NeverApplicable;
@@ -812,8 +821,12 @@ function(ri)
         return NeverApplicable;
     fi;
     mp := MovedPoints(grp);
+    deg := Size(mp);
     # Decide whether group is a giant
-    if RECOG.IsGiant(grp,mp) = fail then
+    # RECOG.IsGiant can only succeed for deg>7
+    if deg<=7 then
+        return NeverApplicable;
+    elif RECOG.IsGiant(grp,mp) = fail then
         return TemporaryFailure;
     fi;
     grpmem := Group(ri!.gensHmem);
@@ -833,13 +846,13 @@ function(ri)
     ri!.giantinfo := res;
     SetFilterObj(ri,IsLeaf);
     F := FreeGroup(2); # for presentation
-    deg := Size(mp);
     # We set the presentations of Sn and An from
     # [CM80] "Generators and relations for discrete groups", (6.21), 6.3.
     # They coincide with the ones in
     # [BLN+03] "A black-box group algorithm for recognizing finite symmetric 
     # and alternating groups, I", (2.1), (2.2), (2.3),
     # except that one relation in (2.1) and one relation in (2.3) is incorrect.
+    # Since deg>=8, we do not have to worry about small edge cases.
     if res.stamp = "An" then
         SetSize(ri,Factorial(Length(mp))/2);
         SetIsRecogInfoForSimpleGroup(ri,true);
@@ -848,26 +861,23 @@ function(ri)
             Add(rels, (F.2*F.1)^deg);
             rels := Concatenation(
                 rels,
-                List([1..QuoInt(n-3, 2)], k -> (F.1*F.2^(-k)*F.1*F.2^k)^2)
+                List([1..QuoInt(deg-3, 2)], k -> (F.1*F.2^(-k)*F.1*F.2^k)^2)
             );
         else
             Add(rels, (F.2*F.1)^(deg-1));
             rels := Concatenation(
                 rels,
-                List([1..QuoInt(n-2, 2)], k -> (F.1^((-1)^k)*F.2^-k*F.1*F.2^k)^2)
+                List([1..QuoInt(deg-2, 2)], k -> (F.1^((-1)^k)*F.2^-k*F.1*F.2^k)^2)
             );
         fi;
     else
         SetSize(ri,Factorial(Length(mp)));
         SetIsRecogInfoForAlmostSimpleGroup(ri,true);
-        # if deg>2 then
-            # Relations on F.1=(1,2), F.2 = (1,...,deg) from [CM80, (6.21)]
-            # TODO: Is this correct for d=1, 2?
-            rels := [ F.1^2, F.2^deg, (F.1*F.2)^(deg-1), (F.1*(F.1^F.2))^3 ];
-            rels := Concatenation(
-                rels, List([2..QuoInt(deg, 2)], j -> (F.1*(F.1^(F.2^j)))^2)
-            );
-        # fi;
+        # Relations on F.1=(1,2), F.2 = (1,...,deg) from [CM80, (6.21)]
+        rels := [ F.1^2, F.2^deg, (F.1*F.2)^(deg-1), (F.1*(F.1^F.2))^3 ];
+        rels := Concatenation(
+            rels, List([2..QuoInt(deg, 2)], j -> (F.1*(F.1^(F.2^j)))^2)
+        );
     fi;
     SetNiceGens(ri,StripMemory(res.gens));
     SetStdPresentation(ri,F / rels);

--- a/tst/working/slow/GiantPresentation.tst
+++ b/tst/working/slow/GiantPresentation.tst
@@ -1,0 +1,38 @@
+#
+gap> START_TEST("GiantPresentation.tst");
+gap> oldInfoLevel := InfoLevel(InfoRecog);;
+gap> SetInfoLevel(InfoRecog, 0);;
+gap> testGiantPres := function(n, stamp)
+>  local size, giant, grp, ri, Fp, F, hom, rel;
+>  if stamp = "Sn" then
+>    size := Factorial(n);
+>    giant := SymmetricGroup;
+>  elif stamp = "An" then
+>    size := Factorial(n)/2;
+>    giant := AlternatingGroup;
+>  else
+>    Display("Incorrect argument for test function");
+>  fi;
+>  grp := giant(n);
+>  ri := TryFindHomMethod(grp, FindHomMethodsPerm.Giant, false);
+>  if not HasStdPresentation(ri) then
+>    Display("StdPresentation was not set for ", stamp, ", n=", n);
+>  fi;
+>  Fp := StdPresentation(ri);
+>  if Size(Fp) <> size then
+>    Display("StdPresentation for ", stamp, ", n=", n, ", has incorrect size");
+>  fi;
+>  F := FreeGroupOfFpGroup(Fp);
+>  hom := GroupHomomorphismByImages(F, grp, GeneratorsOfGroup(F), NiceGens(ri));
+>  for rel in RelatorsOfFpGroup(Fp) do
+>    if not IsOne(hom(rel)) then
+>      Display(stamp, ", for n=", n, ", does not satisfy the relations of StdPresentation");
+>    fi;
+>  od;
+> end;;
+gap> for n in [8..10] do testGiantPres(n, "Sn"); od;;
+gap> for n in [8..10] do testGiantPres(n, "An"); od;;
+
+#
+gap> SetInfoLevel(InfoRecog, oldInfoLevel);
+gap> STOP_TEST("GiantPresentation.tst");

--- a/tst/working/slow/GiantPresentation.tst
+++ b/tst/working/slow/GiantPresentation.tst
@@ -2,7 +2,7 @@
 gap> START_TEST("GiantPresentation.tst");
 gap> oldInfoLevel := InfoLevel(InfoRecog);;
 gap> SetInfoLevel(InfoRecog, 0);;
-gap> testGiantPres := function(n, stamp)
+gap> testGiantPres := function(n, stamp, checkSize)
 >  local size, giant, grp, ri, Fp, F, hom, rel;
 >  if stamp = "Sn" then
 >    size := Factorial(n);
@@ -19,7 +19,7 @@ gap> testGiantPres := function(n, stamp)
 >    Display("StdPresentation was not set for ", stamp, ", n=", n);
 >  fi;
 >  Fp := StdPresentation(ri);
->  if Size(Fp) <> size then
+>  if checkSize and Size(Fp) <> size then
 >    Display("StdPresentation for ", stamp, ", n=", n, ", has incorrect size");
 >  fi;
 >  F := FreeGroupOfFpGroup(Fp);
@@ -30,8 +30,10 @@ gap> testGiantPres := function(n, stamp)
 >    fi;
 >  od;
 > end;;
-gap> for n in [8..10] do testGiantPres(n, "Sn"); od;;
-gap> for n in [8..10] do testGiantPres(n, "An"); od;;
+gap> for n in [8..10] do testGiantPres(n, "Sn", true); od;;
+gap> for n in [8..10] do testGiantPres(n, "An", true); od;;
+gap> for n in [11..20] do testGiantPres(n, "Sn", false); od;;
+gap> for n in [11..20] do testGiantPres(n, "An", false); od;;
 
 #
 gap> SetInfoLevel(InfoRecog, oldInfoLevel);


### PR DESCRIPTION
Minor changes beside the title:
- Fixes `TryFindHomMethod`. (From what I understand, this adapts `TryFindHomMethod` to a change that was made in a recent PR, maybe someone knows which one.)
- Expands the documentation of the recog method "MovesOnlySmallPoints".
- Clarifies that the recog method "Giant" works only for permutation groups of degree at least 8 because `IsGiant` does.