### PR TITLE
Handle invalid projective PSL2 normalization

### DIFF
--- a/gap/projective/classicalnatural.gi
+++ b/gap/projective/classicalnatural.gi
@@ -736,7 +736,7 @@ end;
 # Now the code for writing SLPs:
 
 SLPforElementFuncsProjective.PSL2 := function(ri,x)
-  local det,log,slp,y,z,pos,s;
+  local det,pos,root,s,slp,y;
   ri!.fakegens.count := ri!.fakegens.count + 1;
   if ri!.fakegens.count > 1000 then
       ri!.fakegens := RECOG.InitSLfake(ri!.field,2);
@@ -745,9 +745,13 @@ SLPforElementFuncsProjective.PSL2 := function(ri,x)
   y := ri!.nicebas * x * ri!.nicebasi;
   det := DeterminantMat(y);
   if not IsOne(det) then
-      z := PrimitiveRoot(ri!.field);
-      log := LogFFE(det,z);
-      y := y * z^(-log*ri!.gcd.coeff1/ri!.gcd.gcd);
+      # In the projective image, det only has to be a square. If it is not,
+      # then the PSL2 recognition path was too optimistic for this element.
+      root := RootFFE(ri!.field,1/det,2);
+      if root = fail then
+          return fail;
+      fi;
+      y := y * root;
   fi;
   # At this point, y has determinant 1; but we consider it modulo scalars.
   # To make sure that different coset reps behave the same, we scale it
@@ -841,7 +845,7 @@ end;
 BindRecogMethod("FindHomMethodsProjective", "ClassicalNatural",
 "check whether it is a classical group in its natural representation",
 function(ri)
-  local g,changed,classical,d,det,ext,f,gcd,gens,gm,i,p,pr,q,root,std,stdg,z;
+  local g,changed,classical,d,det,ext,f,gcd,gens,gm,i,p,pr,q,root,std,stdg;
   g := Grp(ri);
   d := ri!.dimension;
   f := ri!.field;
@@ -866,14 +870,15 @@ function(ri)
   # Now get rid of nasty determinants:
   gens := ShallowCopy(GeneratorsOfGroup(g));
   changed := false;
-  z := Z(q);
   gcd := Gcdex(d,q-1);
   for i in [1..Length(gens)] do
       det := DeterminantMat(gens[i]);
       if not IsOne(det) then
           root := RootFFE(f, det^-1, d);
           if root = fail then
-              ErrorNoReturn("Should not have happened, 15634, tell Max!");
+              Info(InfoRecog,2,
+                   "ClassicalNatural: determinant cannot be normalized in field.");
+              return fail;
           fi;
           gens[i] := gens[i] * root;
           changed := true;

--- a/tst/working/quick/bugfix.tst
+++ b/tst/working/quick/bugfix.tst
@@ -168,6 +168,30 @@ gap> ri := RecognizeGroup(ClassicalMaximals("L",4,3)[8]);;
 gap> IsReady(ri);
 true
 
+# Issue #317: false PSL2 recognition must fall back cleanly instead of
+# reaching invalid determinant-root normalization or late verification errors.
+# See https://github.com/gap-packages/recog/issues/317
+gap> G := Group(Z(5)^0*[
+>   [ [ 0, 2, 0, 2 ], [ 1, 4, 4, 4 ], [ 0, 4, 0, 0 ], [ 3, 2, 0, 0 ] ],
+>   [ [ 0, 2, 0, 2 ], [ 4, 4, 1, 4 ], [ 0, 1, 0, 0 ], [ 3, 3, 0, 0 ] ],
+>   [ [ 1, 0, 0, 0 ], [ 0, 4, 0, 0 ], [ 0, 0, 4, 0 ], [ 0, 0, 0, 1 ] ],
+>   [ [ 2, 0, 0, 0 ], [ 0, 2, 0, 0 ], [ 0, 0, 2, 0 ], [ 0, 0, 0, 2 ] ],
+>   [ [ 0, 0, 0, 1 ], [ 0, 2, 0, 0 ], [ 0, 0, 1, 0 ], [ 2, 0, 0, 0 ] ]
+> ]);;
+gap> i := 115;; Reset(GlobalMersenneTwister, i);; Reset(GlobalRandomSource, i);;
+gap> ri := RecognizeGroup(G);;
+gap> IsReady(ri);
+true
+gap> ForAll(GeneratorsOfGroup(G), x -> SLPforElement(ri, x) <> fail);
+true
+gap> i := 9;; Reset(GlobalRandomSource, i);; Reset(GlobalMersenneTwister, i);;
+gap> H := ClassicalMaximals("L",4,7)[4];;
+gap> ri := RecognizeGroup(H);;
+gap> IsReady(ri);
+true
+gap> ForAll(GeneratorsOfGroup(H), x -> SLPforElement(ri, x) <> fail);
+true
+
 # Issue #343: extracting a strict lower block diagonal from an immutable
 # identity matrix over GF(2) must not create phantom ones.
 gap> blocks := [ [ 1 .. 11 ], [ 12 .. 22 ], [ 23 .. 33 ], [ 34 .. 44 ],


### PR DESCRIPTION
Make the ClassicalNatural PSL2 path use finite-field square roots
for determinant normalization and reject the branch cleanly when
the required root does not exist.

Fixes #317

Co-authored-by: Codex <codex@openai.com>
