### PR TITLE
Recover D247 from false tensor witnesses

### DIFF
--- a/gap/projective/d247.gi
+++ b/gap/projective/d247.gi
@@ -185,6 +185,26 @@ RECOG.DirectFactorsAction := function(data,el)
   return PermList(res);
 end;
 
+RECOG.TryDirectFactorsAction := function(ri,G,facgens,mult)
+  local H,hom,orb;
+
+  orb := RECOG.DirectFactorsFinder(GeneratorsOfGroup(G), facgens, mult,
+                                   ri!.isequal);
+  if orb = fail then
+      return fail;
+  fi;
+
+  H := GroupWithGenerators(orb[2]);
+  hom := GroupHomByFuncWithData(G,H,RECOG.DirectFactorsAction,
+             rec( o := orb[1], eq := ri!.isequal ) );
+  SetHomom(ri,hom);
+  Setmethodsforimage(ri,FindHomDbPerm);
+  Info(InfoRecog,2,"D247: Success, found D7 with action on ",
+       mult," direct factors.");
+  ri!.comment := "D7TensorInduced";
+  return Success;
+end;
+
 RECOG.IsPower := function(d)
   local f, e, g, l, dd;
   # Intended for small d
@@ -208,7 +228,8 @@ RECOG.SortOutReducibleNormalSubgroup :=
     # Only call this with absolutely irreducible G!
     # Only call this if we already know that G is not C3!
 
-    local H,a,basis,collf,conjgensG,f,hom,homcomp,homs,homsimg,kro,o,r,subdim;
+    local H,a,basis,collf,conjgensG,dim,f,hom,homcomp,homs,homsimg,kro,mult,o,
+          r,res,subdim;
 
     f := ri!.field;
     collf := MTX.CollectedFactors(m);
@@ -242,7 +263,15 @@ RECOG.SortOutReducibleNormalSubgroup :=
         if not ForAll(kro, k -> k[1]) then
             Info(InfoRecog,1,"VERY, VERY, STRANGE!");
             Info(InfoRecog,1,"False alarm, was not a tensor decomposition.");
-            ErrorNoReturn("This should never have happened (346), tell Max.");
+            dim := MTX.Dimension(m);
+            mult := First([2..20],i->subdim^i = dim);
+            if mult <> fail then
+                res := RECOG.TryDirectFactorsAction(ri,G,ngens,mult);
+                if res = Success then
+                    return Success;
+                fi;
+            fi;
+            return TemporaryFailure;
         fi;
 
         H := GroupWithGenerators(conjgensG);
@@ -313,7 +342,7 @@ RECOG.SortOutReducibleSecondNormalSubgroup :=
     # Only call this if we already know that G is not C3!
     # Only call this if the upper normal subgroup was still irreducible!
 
-    local H,collf,dim,hom,mult,orb,subdim;
+    local collf,dim,mult,res,subdim;
 
     collf := MTX.CollectedFactors(mm);
     if Length(collf) = 1 then
@@ -321,18 +350,8 @@ RECOG.SortOutReducibleSecondNormalSubgroup :=
         dim := MTX.Dimension(mm);
         mult := First([2..20],i->subdim^i = dim);
         if mult <> fail then
-            orb := RECOG.DirectFactorsFinder(GeneratorsOfGroup(G),
-                                             nngens,mult,ri!.isequal);
-            if orb <> fail then
-                H := GroupWithGenerators(orb[2]);
-                hom := GroupHomByFuncWithData(G,H,
-                           RECOG.DirectFactorsAction,
-                           rec( o := orb[1], eq := ri!.isequal) );
-                SetHomom(ri,hom);
-                Setmethodsforimage(ri,FindHomDbPerm);
-                Info(InfoRecog,2,"D247: Success, found D7 with action",
-                     " on ",mult," direct factors.");
-                ri!.comment := "D7TensorInduced";
+            res := RECOG.TryDirectFactorsAction(ri,G,nngens,mult);
+            if res = Success then
                 return Success;
             else
                 Info(InfoRecog,2,"D247: Did not find direct factors!");

--- a/tst/working/quick/bugfix.tst
+++ b/tst/working/quick/bugfix.tst
@@ -261,6 +261,29 @@ gap> Size(ri);
 gap> ForAll(GeneratorsOfGroup(H), x -> SLPforElement(ri, x) <> fail);
 true
 
+# Issue #450: a D247 tensor witness contradicted by a tensor-factor swap
+# must not raise an internal error.
+# See https://github.com/gap-packages/recog/issues/450
+gap> f := GF(3);;
+gap> g1 := [ [ Z(3)^0, Z(3)^0 ], [ 0*Z(3), Z(3)^0 ] ];;
+gap> g2 := [ [ 0*Z(3), Z(3)^0 ], [ Z(3)^0, 0*Z(3) ] ];;
+gap> i2 := IdentityMat(2, f);;
+gap> ngens := [ KroneckerProduct(g1, i2), KroneckerProduct(g2, i2) ];;
+gap> hgens := [ KroneckerProduct(i2, g1), KroneckerProduct(i2, g2) ];;
+gap> swap := [ [ Z(3)^0, 0*Z(3), 0*Z(3), 0*Z(3) ],
+>   [ 0*Z(3), 0*Z(3), Z(3)^0, 0*Z(3) ],
+>   [ 0*Z(3), Z(3)^0, 0*Z(3), 0*Z(3) ],
+>   [ 0*Z(3), 0*Z(3), 0*Z(3), Z(3)^0 ] ];;
+gap> G := Group(Concatenation(ngens, hgens, [ swap ]));;
+gap> m := GModuleByMats(ngens, f);;
+gap> ri := RecogNode(G, true);;
+gap> RECOG.SortOutReducibleNormalSubgroup(ri, G, ngens, m);
+true
+gap> ri!.comment;
+"D7TensorInduced"
+gap> Size(Image(Homom(ri)));
+2
+
 #
 gap> SetInfoLevel(InfoRecog, oldInfoLevel);
 gap> STOP_TEST("bugfix.tst");


### PR DESCRIPTION
Reuse the D7 direct-factor fallback for false D247 tensor
witnesses instead of raising internal error 346.

Fixes #450

Co-authored-by: Codex <codex@openai.com>
