### PR TITLE
Bound ComputeSimpleSocle retries

### DIFF
--- a/gap/projective/almostsimple.gi
+++ b/gap/projective/almostsimple.gi
@@ -658,29 +658,50 @@ end;
 # is used in FindHomMethodsProjective.ComputeSimpleSocle
 # it computes the non-abelian simple socle randomly (it might
 # underestimates it)
-# if called for an abelian group (even a group with nilpotence class smaller
-# than 3?) it runs in an infinite loop
+# if it cannot find a suitable witness quickly enough, it returns fail
 RECOG.simplesocle := function(ri,g)
-  local x,y,comm,comm2,comm3,gensH;
+  local x,comm,comm2,comm3,gensH,bound,tries,FindNonTrivial;
 
-  repeat
-    x:=RandomElm(ri,"simplesocle",true).el;
-  until not ri!.isone(x);
+  # If H is almost simple with socle S, then the classification of finite
+  # simple groups implies H''' = S. This is because H / S embeds into Out(S),
+  # which is solvable of derived length at most 3. Thus the normal closure in
+  # H of any non-trivial element of H''' is S. Since both the random search
+  # and FastNormalClosure are only heuristics here, this routine must be
+  # allowed to give up.
+  bound := 5 * ri!.dimension;  # this is an arbitrary bound, could be tuned
+  tries := 0;
+  FindNonTrivial := function(f)
+    local i,el;
+    while tries < bound do
+        tries := tries + 1;
+        el := f(RandomElm(ri,"simplesocle",false).el);
+        if not ri!.isone(el) then
+            return el;
+        fi;
+    od;
+    return fail;
+  end;
 
-  repeat
-    y:=RandomElm(ri,"simplesocle",true).el;
-    comm:=Comm(x,y);
-  until not ri!.isone(comm);
+  # find a non-trivial element of g
+  x := FindNonTrivial(x -> x);
+  if x = fail then
+      return fail;
+  fi;
 
-  repeat
-    y:=RandomElm(ri,"simplesocle",true).el;
-    comm2:=Comm(comm,comm^y);
-  until not ri!.isone(comm2);
+  comm := FindNonTrivial(y -> Comm(x,y));
+  if comm = fail then
+      return fail;
+  fi;
 
-  repeat
-    y:=RandomElm(ri,"simplesocle",true).el;
-    comm3:=Comm(comm2,comm2^y);
-  until not ri!.isone(comm3);
+  comm2 := FindNonTrivial(y -> Comm(comm,comm^y));
+  if comm2 = fail then
+      return fail;
+  fi;
+
+  comm3 := FindNonTrivial(y -> Comm(comm2,comm2^y));
+  if comm3 = fail then
+      return fail;
+  fi;
 
   gensH:=FastNormalClosure(g,[comm3],20);
 
@@ -697,10 +718,15 @@ end;
 BindRecogMethod("FindHomMethodsProjective", "ComputeSimpleSocle",
 "compute simple socle of almost simple group",
 function(ri)
-  local G,x;
+  local G,soclegens,x;
   G := Grp(ri);
   RECOG.SetPseudoRandomStamp(G,"ComputeSimpleSocle");
-  ri!.simplesocle := Group(RECOG.simplesocle(ri,G));
+  soclegens := RECOG.simplesocle(ri,G);
+  if soclegens = fail then
+      Info(InfoRecog,2,"ComputeSimpleSocle: giving up.");
+      return TemporaryFailure;
+  fi;
+  ri!.simplesocle := Group(soclegens);
   ri!.simplesoclepr := ProductReplacer(ri!.simplesocle);
   ri!.simplesoclerand := EmptyPlist(100);
   Append(ri!.simplesoclerand,GeneratorsOfGroup(ri!.simplesocle));
@@ -754,6 +780,9 @@ BindRecogMethod("FindHomMethodsProjective", "ThreeLargeElOrders",
 function(ri)
   local G,hint,name,namecat,p,res;
   G := Grp(ri);
+  if not IsBound(ri!.simplesocle) then
+      return TemporaryFailure;
+  fi;
   RECOG.SetPseudoRandomStamp(G,"ThreeLargeElOrders");
   ri!.simplesoclerandp := 0;
   p := RECOG.findchar(ri,ri!.simplesocle,RECOG.RandElFuncSimpleSocle);

--- a/gap/projective/almostsimple/lietype.gi
+++ b/gap/projective/almostsimple/lietype.gi
@@ -824,6 +824,9 @@ BindRecogMethod("FindHomMethodsProjective", "LieTypeNonConstr",
 function(ri)
     local G,count,dim,f,i,ords,p,q,r,res;
     G := Grp(ri);
+    if not IsBound(ri!.simplesocle) then
+        return TemporaryFailure;
+    fi;
     RECOG.SetPseudoRandomStamp(G,"LieTypeNonConstr");
     dim := ri!.dimension;
     f := ri!.field;

--- a/tst/working/quick/bugfix.tst
+++ b/tst/working/quick/bugfix.tst
@@ -111,6 +111,12 @@ gap> G:=Group(List(gens, g -> ImmutableMatrix(GF(9), g)));; # ... but compress g
 gap> RECOG.SmallHomomorphicImageProjectiveGroup(G);  # this call used to raise an error
 fail
 
+# Issue #133: RECOG.simplesocle on an abelian group would get stuck in an infinite loop
+gap> G := Group([DiagonalMatrix(Z(3)*[1,2]), DiagonalMatrix(Z(3)*[2,1])]);;
+gap> ri:=RecogNode(G,true,rec());;
+gap> ForAll([1..100], i -> RECOG.simplesocle(ri,G) = fail);
+true
+
 # Issue #295: the C6 recognizer must reject inconsistent radical block splits
 # instead of raising "what's wrong2?" for this reducible alternating-group
 # factor.
@@ -283,6 +289,30 @@ gap> ri!.comment;
 "D7TensorInduced"
 gap> Size(Image(Homom(ri)));
 2
+
+# Issue #466: ComputeSimpleSocle must give up on non-almost-simple input
+# instead of looping forever in its random search for a nontrivial element
+# of the third derived subgroup.
+# See https://github.com/gap-packages/recog/issues/466
+gap> z:=Z(3^2);; G:=Group(z^0 *
+> [ [ [ z^2, 0, 0, 0 ], [ 0, z^2, 0, 0 ], [ 0, 0, z^2, 0 ], [ 0, 0, 0, z^2 ] ],
+>   [ [ 1, 0, 0, 0 ], [ 0, 2, 0, 0 ], [ 0, 0, 1, 0 ], [ 0, 0, 0, 2 ] ],
+>   [ [ 1, 0, 0, 0 ], [ 0, 1, 0, 0 ], [ 0, 0, 2, 0 ], [ 0, 0, 0, 2 ] ],
+>   [ [ 0, 1, 0, 0 ], [ 1, 0, 0, 0 ], [ 0, 0, 0, 1 ], [ 0, 0, 1, 0 ] ],
+>   [ [ 0, 0, 1, 0 ], [ 0, 0, 0, 1 ], [ 1, 0, 0, 0 ], [ 0, 1, 0, 0 ] ],
+>   [ [ z^7, 0, 0, 0 ], [ 0, z, 0, 0 ], [ 0, 0, z^7, 0 ], [ 0, 0, 0, z ] ],
+>   [ [ z^7, 0, 0, 0 ], [ 0, z^7, 0, 0 ], [ 0, 0, z, 0 ], [ 0, 0, 0, z ] ],
+>   [ [ 1, 1, 0, 0 ], [ 1, 2, 0, 0 ], [ 0, 0, 1, 1 ], [ 0, 0, 1, 2 ] ],
+>   [ [ 1, 0, 1, 0 ], [ 0, 1, 0, 1 ], [ 1, 0, 2, 0 ], [ 0, 1, 0, 2 ] ],
+>   [ [ z^7, 0, 0, 0 ], [ 0, 0, 0, z^7 ], [ 0, 0, z^7, 0 ], [ 0, z^7, 0, 0 ] ],
+> ]);;
+gap> i:=279;; Reset(GlobalRandomSource,i);; Reset(GlobalMersenneTwister,i);;
+gap> ri:=RecognizeGroup(G);;
+gap> IsReady(ri);
+true
+gap> ri:=RecogNode(G,true,rec());;
+gap> CallRecogMethod(FindHomMethodsProjective.ComputeSimpleSocle,ri) <> Success;
+true
 
 #
 gap> SetInfoLevel(InfoRecog, oldInfoLevel);


### PR DESCRIPTION
Bound the random simple-socle search and let it give up.
Guard later almost-simple methods when no socle was found.

Fixes #466. Resolves #133

Co-authored-by: Codex <codex@openai.com>