### PR TITLE
Quiet recoverable D247 direct-factor warning

### DIFF
--- a/gap/projective/d247.gi
+++ b/gap/projective/d247.gi
@@ -148,7 +148,7 @@ RECOG.DirectFactorsFinder := function(gens,facgens,k,eq)
   od;
 
   if Length(o) < k then
-      Info(InfoRecog,1,"Strange, found fewer direct factors than expected!");
+      Info(InfoRecog,2,"Strange, found fewer direct factors than expected!");
       return fail;
   fi;
 


### PR DESCRIPTION
Lower the 'fewer direct factors than expected' message in D247
from InfoRecog level 1 to 2. The warning is reproducible on a
successful recognition path and currently reports a recoverable
false witness rather than a user-actionable failure.

Keep the 'more direct factors than expected' message at level 1,
since that case still looks like a stronger inconsistency.

Co-authored-by: Codex <codex@openai.com>
