### PR TITLE
Verify projective action kernels immediately

### DIFF
--- a/gap/projective/c3c5.gi
+++ b/gap/projective/c3c5.gi
@@ -866,6 +866,7 @@ function(ri)
       a := OrbActionHomomorphism(G,o);
       SetHomom(ri,a);
       Setmethodsforimage(ri,FindHomDbPerm);
+      Setimmediateverification(ri,true);
 
       return Success;
 

--- a/gap/projective/d247.gi
+++ b/gap/projective/d247.gi
@@ -199,6 +199,7 @@ RECOG.TryDirectFactorsAction := function(ri,G,facgens,mult)
              rec( o := orb[1], eq := ri!.isequal ) );
   SetHomom(ri,hom);
   Setmethodsforimage(ri,FindHomDbPerm);
+  Setimmediateverification(ri,true);
   Info(InfoRecog,2,"D247: Success, found D7 with action on ",
        mult," direct factors.");
   ri!.comment := "D7TensorInduced";


### PR DESCRIPTION
Mark the D247 direct-factors action and the C3C5
homogeneous-components action for immediate verification. Both
actions are projectively correct, but verification exposed that
their initial exact kernel generators can miss an index-2 layer,
so the outer node must verify and enlarge the kernel before
claiming readiness.

This restores the issue #317 reproducers under verification
without reopening the invalid PSL2 normalization path.

Co-authored-by: Codex <codex@openai.com>
