### PR TITLE
Fail fast on bad low-index start hints

### DIFF
--- a/gap/projective/almostsimple.gi
+++ b/gap/projective/almostsimple.gi
@@ -210,13 +210,20 @@ InstallGlobalFunction( DoHintedLowIndex, function(ri,G,hint)
 
   fld := ri!.field;
   d := ri!.dimension;
+  triesinnerlimit := RECOG.ParseNumber(hint.triesforgens,d,"1d");
+  trieslimit := RECOG.ParseNumber(hint.tries,d,10);
+  numberrandgens := RECOG.ParseNumber(hint.numberrandgens,d,2);
+  orblenlimit := RECOG.ParseNumber(hint.orblenlimit,d,"4d");
   if IsBound(hint.elordersstart) then
       i := 0;
       repeat
           i := i + 1;
-          if i > 10000 then
-              ErrorNoReturn("possible infinite loop in DoHintedLowIndex, ",
-                            "wrong hints?");
+          if i > triesinnerlimit then
+              Info(InfoRecog,2,
+                   "Did not find a start element with one of the hinted ",
+                   "orders ",hint.elordersstart," after ",triesinnerlimit,
+                   " tries.");
+              return fail;
           fi;
           x := PseudoRandom(G);
       until Order(x) in hint.elordersstart;
@@ -226,10 +233,6 @@ InstallGlobalFunction( DoHintedLowIndex, function(ri,G,hint)
   fi;
 
   tries := 0;
-  numberrandgens := RECOG.ParseNumber(hint.numberrandgens,d,2);
-  triesinnerlimit := RECOG.ParseNumber(hint.triesforgens,d,"1d");
-  trieslimit := RECOG.ParseNumber(hint.tries,d,10);
-  orblenlimit := RECOG.ParseNumber(hint.orblenlimit,d,"4d");
   Info(InfoRecog,3,"Using numberrandgens=",numberrandgens,
        " triesinnerlimit=",triesinnerlimit," trieslimit=",trieslimit,
        " orblenlimit=",orblenlimit);

--- a/tst/working/quick/bugfix.tst
+++ b/tst/working/quick/bugfix.tst
@@ -392,6 +392,18 @@ gap> ri:=RecogNode(G,true,rec());;
 gap> CallRecogMethod(FindHomMethodsProjective.ComputeSimpleSocle,ri) <> Success;
 true
 
+# Issue #445: cross-characteristic PSL2 low-index hints must fail quickly
+# and allow recognition to continue, instead of exhausting a huge random
+# search and raising an internal error.
+# See https://github.com/gap-packages/recog/issues/445
+gap> m := ClassicalMaximals("L",6,7);;
+gap> i := 44;; Reset(GlobalRandomSource, i);; Reset(GlobalMersenneTwister, i);;
+gap> ri := RecognizeGroup(m[21]);;
+gap> IsReady(ri);
+true
+gap> ForAll(GeneratorsOfGroup(m[21]), x -> SLPforElement(ri, x) <> fail);
+true
+
 #
 gap> SetInfoLevel(InfoRecog, oldInfoLevel);
 gap> STOP_TEST("bugfix.tst");

--- a/tst/working/quick/bugfix.tst
+++ b/tst/working/quick/bugfix.tst
@@ -396,12 +396,31 @@ true
 # and allow recognition to continue, instead of exhausting a huge random
 # search and raising an internal error.
 # See https://github.com/gap-packages/recog/issues/445
-gap> m := ClassicalMaximals("L",6,7);;
+gap> G:=Group(Z(7)^0*[   # this group is ClassicalMaximals("L",6,7)[21];
+> [[2,5,0,2,1,0],
+>  [1,4,0,4,3,0],
+>  [6,5,1,2,3,0],
+>  [5,0,0,1,2,0],
+>  [3,5,0,2,0,0],
+>  [2,6,0,1,6,1]],
+> [[3,6,5,3,6,1],
+>  [0,3,4,1,2,0],
+>  [6,3,0,6,6,0],
+>  [4,3,0,4,0,0],
+>  [0,6,5,3,0,0],
+>  [0,0,4,1,1,6]],
+> [[3,0,0,0,0,0],
+>  [0,3,0,0,0,0],
+>  [0,0,3,0,0,0],
+>  [0,0,0,3,0,0],
+>  [0,0,0,0,3,0],
+>  [0,0,0,0,0,3]]
+> ]);;
 gap> i := 44;; Reset(GlobalRandomSource, i);; Reset(GlobalMersenneTwister, i);;
-gap> ri := RecognizeGroup(m[21]);;
+gap> ri := RecognizeGroup(G);;
 gap> IsReady(ri);
 true
-gap> ForAll(GeneratorsOfGroup(m[21]), x -> SLPforElement(ri, x) <> fail);
+gap> ForAll(GeneratorsOfGroup(G), x -> SLPforElement(ri, x) <> fail);
 true
 
 #


### PR DESCRIPTION
Treat an elordersstart miss in DoHintedLowIndex as an ordinary
hint failure instead of an internal error. Use the hint's existing
triesforgens budget for the startup search and let recognition
continue with other methods.

Fixes #445.

Co-authored-by: Codex <codex@openai.com>
