### PR TITLE
Switch method return values from booleans to symbolic names

### DIFF
--- a/gap/matrix/matimpr.gi
+++ b/gap/matrix/matimpr.gi
@@ -150,7 +150,7 @@ function(ri)
   RECOG.SetPseudoRandomStamp(Grp(ri),"LowIndex");
   res := RECOG.SmallHomomorphicImageProjectiveGroup(Grp(ri));
   if res = fail then
-      return fail; # FIXME: fail = TemporaryFailure here really correct?
+      return TemporaryFailure; # FIXME: TemporaryFailure here really correct?
   else
       res := res[1];
       # Now distinguish between a block system and just an orbit:

--- a/gap/projective/almostsimple.gi
+++ b/gap/projective/almostsimple.gi
@@ -115,7 +115,7 @@ InstallGlobalFunction( DoHintedStabChain, function(ri,G,hint)
         Info(InfoRecog,1,"Expected BBox finder for stdgens of ",hint.name,
              " not availabe!");
         Info(InfoRecog,1,"Check your AtlasRep installation!");
-        return fail;
+        return TemporaryFailure;
     fi;
     gm := Group(ri!.gensHmem);
     gm!.pseudorandomfunc := [rec(
@@ -126,7 +126,7 @@ InstallGlobalFunction( DoHintedStabChain, function(ri,G,hint)
                               rec( orderfunction := RECOG.ProjectiveOrder ) );
     if stdgens = fail or stdgens = "timeout" then
         Info(InfoRecog,2,"Stdgens finder did not succeed for ",hint.name);
-        return fail;
+        return TemporaryFailure;
     fi;
     stdgens := stdgens.gens;
     #Setslptostd(ri,SLPOfElms(stdgens));
@@ -146,7 +146,7 @@ InstallGlobalFunction( DoHintedStabChain, function(ri,G,hint)
                 Info(InfoRecog,1,"Expected maximal subgroup slp of ",hint.name,
                      " not available!");
                 Info(InfoRecog,1,"Check your AtlasRep installation!");
-                return fail;
+                return TemporaryFailure;
             fi;
             maxgens := ResultOfStraightLineProgram(s.program,
                                                    StripMemory(stdgens));
@@ -195,11 +195,11 @@ InstallGlobalFunction( DoHintedStabChain, function(ri,G,hint)
             fi;
             SetIsRecogInfoForAlmostSimpleGroup(ri,true);
             ri!.comment := hint.name;
-            return true;
+            return Success;
         od;
     fi;
     Info( InfoRecog, 2, "Got stab chain hint, not yet implemented!" );
-    return fail;
+    return TemporaryFailure;
   end );
 
 InstallGlobalFunction( DoHintedLowIndex, function(ri,G,hint)
@@ -223,7 +223,7 @@ InstallGlobalFunction( DoHintedLowIndex, function(ri,G,hint)
                    "Did not find a start element with one of the hinted ",
                    "orders ",hint.elordersstart," after ",triesinnerlimit,
                    " tries.");
-              return fail;
+              return TemporaryFailure;
           fi;
           x := PseudoRandom(G);
       until Order(x) in hint.elordersstart;
@@ -305,7 +305,7 @@ InstallGlobalFunction( DoHintedLowIndex, function(ri,G,hint)
                   fi;
                   SetHomom(ri,hom);
                   Setmethodsforimage(ri,FindHomDbPerm);
-                  return true;
+                  return Success;
               fi;
           else
               Info(InfoRecog,2,"Subspace dimension not as expected, ",
@@ -314,7 +314,7 @@ InstallGlobalFunction( DoHintedLowIndex, function(ri,G,hint)
       fi;
       tries := tries + 1;
   until tries > trieslimit;
-  return fail;
+  return TemporaryFailure;
 end );
 
 # We start a database of hints, whenever we discover a certain group, we
@@ -363,7 +363,7 @@ RECOG.ProduceTrivialStabChainHint := function(name,reps,maxes)
           t := Runtime();
           res := DoHintedStabChain(ri,g,hint);
           t := Runtime() - t;
-          if res = true then
+          if res = Success then
               o := ri!.stabilizerchain!.orb;
               x := o[1];
               if IsMatrix(x) then
@@ -791,7 +791,7 @@ function(ri)
   p := RECOG.findchar(ri,ri!.simplesocle,RECOG.RandElFuncSimpleSocle);
   if p = Characteristic(ri!.field) then
       Info(InfoRecog,2,"ThreeLargeElOrders: defining characteristic p=",p);
-      return false; # FIXME: false = NeverApplicable here really correct?
+      return NeverApplicable; # FIXME: NeverApplicable here really correct?
   fi;
   # Try all possibilities:
   Info(InfoRecog,2,"ThreeLargeElOrders: found ",p);
@@ -819,12 +819,12 @@ function(ri)
           fi;
           res := LookupHintForSimple(ri,G,namecat);
       fi;
-      if res = true or res = Success then
+      if res = Success then
           return Success;
       fi;
   od;
   Info(InfoRecog,2,"Did not succeed with hints, giving up...");
-  return fail; # FIXME: fail = TemporaryFailure here really correct?
+  return TemporaryFailure; # FIXME: TemporaryFailure here really correct?
 end);
 
 # RECOG.DegreeAlternating := function (orders)
@@ -1467,20 +1467,20 @@ function(ri)
   for i in [1..Length(l)] do
       Info(InfoRecog,2,"Trying hint for ",RECOG.SporadicsNames[l[i]],"...");
       res := LookupHintForSimple(ri,G,RECOG.SporadicsNames[l[i]]);
-      if res = true then
+      if res = Success then
           return Success;
       fi;
       if IsBound(RECOG.SporadicsWorkers[l[i]]) then
           Info(InfoRecog,2,"Calling its installed worker...");
           res := RECOG.SporadicsWorkers[l[1]](RECOG.SporadicsNames[l[i]],
                                         RECOG.SporadicsSizes[l[i]],ri,G);
-          if res = true then
+          if res = Success then
               return Success;
           fi;
       fi;
       Info(InfoRecog,2,"This did not work.");
   od;
-  return false; # FIXME: false = NeverApplicable here really correct?
+  return NeverApplicable; # FIXME: NeverApplicable here really correct?
 end);
 
 # Data for the function NameSporadic
@@ -1617,7 +1617,7 @@ function(ri)
         Info(InfoRecog, 2, "Trying hint for ", name,
              "...");
         res := LookupHintForSimple(ri, Grp(ri), name);
-        if res = true then return Success; fi;
+        if res = Success then return Success; fi;
         Info(InfoRecog, 2, "This did not work.");
     od;
     return NeverApplicable;

--- a/gap/projective/almostsimple/lietype.gi
+++ b/gap/projective/almostsimple/lietype.gi
@@ -844,11 +844,11 @@ function(ri)
             ri!.comment := r;
             res := LookupHintForSimple(ri,G,r);
             # FIXME: LookupHintForSimple is for sporadics... So why do we use it here?
-            if res = true then
+            if res = Success then
                 return Success;
             fi;
             Info(InfoRecog,2,"LieTypeNonConstr: giving up.");
-            return fail;
+            return TemporaryFailure;
         fi;
         count := count + 1;
         if count > 3 then

--- a/gap/projective/classicalnatural.gi
+++ b/gap/projective/classicalnatural.gi
@@ -857,13 +857,13 @@ function(ri)
   if d = 2 then
       if not RECOG.IsThisSL2Natural(GeneratorsOfGroup(g),f) then
           Info(InfoRecog,2,"ClassicalNatural: Is not PSL_2.");
-          return fail; # FIXME: fail = TemporaryFailure here really correct?
+          return TemporaryFailure; # FIXME: TemporaryFailure here really correct?
       fi;
   else
       classical := RecogniseClassical(g);
       if classical.isSLContained <> true then
           Info(InfoRecog,2,"ClassicalNatural: Is not PSL.");
-          return fail; # FIXME: fail = TemporaryFailure here really correct?
+          return TemporaryFailure; # FIXME: TemporaryFailure here really correct?
       fi;
   fi;
 
@@ -951,6 +951,6 @@ function(ri)
       fi;
   fi;
 
-  return fail; # FIXME: fail = TemporaryFailure here really correct?
+  return TemporaryFailure; # FIXME: TemporaryFailure here really correct?
 
 end);

--- a/gap/projective/d247.gi
+++ b/gap/projective/d247.gi
@@ -363,7 +363,7 @@ RECOG.SortOutReducibleSecondNormalSubgroup :=
     else
         Info(InfoRecog,2,"D247: Restriction not homogeneous!");
     fi;
-    return fail; # FIXME: fail = TemporaryFailure here really correct?
+    return TemporaryFailure; # FIXME: TemporaryFailure here really correct?
   end;
 
 #! @BeginChunk D247
@@ -388,7 +388,7 @@ function(ri)
     if MTX.IsIrreducible(m) then
         if not ispower then
             Info(InfoRecog,4,"Dimension is no power!");
-            return fail; # FIXME: fail = TemporaryFailure here really correct?
+            return TemporaryFailure; # FIXME: TemporaryFailure here really correct?
         fi;
         # we want to look for D7 here, using the same trick again:
         count := 0;
@@ -407,7 +407,7 @@ function(ri)
         if not MTX.IsIrreducible(mm) then
             return RECOG.SortOutReducibleSecondNormalSubgroup(ri,G,nngens,mm);
         fi;
-        return fail; # FIXME: fail = TemporaryFailure here really correct?
+        return TemporaryFailure; # FIXME: TemporaryFailure here really correct?
     fi;
     if InfoLevel(InfoRecog) >= 2 then Print("\n"); fi;
     Info(InfoRecog,2,"D247: Seem to have found something!");
@@ -426,7 +426,7 @@ function(ri)
   for i in [1..9] do
       if InfoLevel(InfoRecog) >= 2 then Print(".\c"); fi;
       res := CheckNormalClosure(x);
-      if res in [true,false] then
+      if res in [Success,NeverApplicable] then
           return res;
       fi;
       x := RECOG.InvolutionJumper(ri!.pr,RECOG.ProjectiveOrder,x,100,true);
@@ -437,7 +437,7 @@ function(ri)
       fi;
   od;
   res := CheckNormalClosure(x);
-  if res in [true,false] then
+  if res in [Success,NeverApplicable] then
       return res;
   fi;
   if InfoLevel(InfoRecog) >= 2 then Print("\n"); fi;

--- a/gap/projective/findnormal.gi
+++ b/gap/projective/findnormal.gi
@@ -718,7 +718,7 @@ end );
 #                   fi;
 #                   res := RECOG.SortOutReducibleSecondNormalSubgroup(ri,G,
 #                                     rr.Ngens,mm);
-#                   if res = true then return Success; fi;
+#                   if res = Success then return Success; fi;
 #                   r := rr;
 #               else
 #                   return fail; # FIXME: fail = TemporaryFailure here really correct?
@@ -740,8 +740,8 @@ function(ri)
   RECOG.SetPseudoRandomStamp(G,"FindElmOfEvenNormal");
   r := FindElmOfEvenNormalSubgroup(G,
           rec( Projective := true, SkipTrivAbelian := true ));
-  if r.success = fail then # FIXME: fail = TemporaryFailure here really correct?
-      return fail; # FIXME: fail = TemporaryFailure here really correct?
+  if r.success = fail then
+      return TemporaryFailure; # FIXME: TemporaryFailure here really correct?
   fi;
   if not IsBound(r.Nready) or not r.Nready then
       r.Ngens := FastNormalClosure(G,[r.el],20);
@@ -773,16 +773,16 @@ function(ri)
               if MTX.IsIrreducible(mm) then
                   Info(InfoRecog,2,
            "FindElmOfEvenNormal: Second normal subgroup was not reducible.");
-                  return fail; # FIXME: fail = TemporaryFailure here really correct?
+                  return TemporaryFailure; # FIXME: TemporaryFailure here really correct?
               fi;
               res := RECOG.SortOutReducibleSecondNormalSubgroup(
                                       ri,G,rr.Ngens,mm);
-              if res = true then
+              if res = Success then
                   return Success;
               fi;
               r := rr;
           until count >= 2;
       fi;
   fi;
-  return fail; # FIXME: fail = TemporaryFailure here really correct?
+  return TemporaryFailure; # FIXME: TemporaryFailure here really correct?
 end);

--- a/tst/working/quick/GenericSnAnUnknownDegree.tst
+++ b/tst/working/quick/GenericSnAnUnknownDegree.tst
@@ -12,7 +12,7 @@ gap> for d in [11] do
 > SdOn2Sets := Action(SymmetricGroup(d), sets, OnSets);;
 > ri := RecogNode(SdOn2Sets);;
 > success := FindHomMethodsGeneric.SnAnUnknownDegree(ri);
-> if not success or not Size(ri) = Factorial(d) then
+> if success <> Success or not Size(ri) = Factorial(d) then
 >   Print("wrong result! degree ", d, "\n");
 > fi;
 > od;
@@ -23,7 +23,7 @@ gap> for d in [11] do
 > SdOn2Sets := Action(AlternatingGroup(d), sets, OnSets);;
 > ri := RecogNode(SdOn2Sets);;
 > success := FindHomMethodsGeneric.SnAnUnknownDegree(ri);
-> if not success or not Size(ri) = Factorial(d)/2 then
+> if success <> Success or not Size(ri) = Factorial(d)/2 then
 >   Print("wrong result! degree ", d, "\n");
 > fi;
 > od;

--- a/tst/working/slow/GenericSnAnUnknownDegree.tst
+++ b/tst/working/slow/GenericSnAnUnknownDegree.tst
@@ -274,7 +274,7 @@ gap> for d in [11 .. 30] do
 > SdOn2Sets := Action(SymmetricGroup(d), sets, OnSets);;
 > ri := RecogNode(SdOn2Sets);;
 > success := FindHomMethodsGeneric.SnAnUnknownDegree(ri);
-> if not success or not Size(ri) = Factorial(d) then
+> if success <> Success or not Size(ri) = Factorial(d) then
 >   Print("wrong result! degree ", d, "\n");
 > fi;
 > od;
@@ -285,7 +285,7 @@ gap> for d in [11 .. 30] do
 > SdOn2Sets := Action(AlternatingGroup(d), sets, OnSets);;
 > ri := RecogNode(SdOn2Sets);;
 > success := FindHomMethodsGeneric.SnAnUnknownDegree(ri);
-> if not success or not Size(ri) = Factorial(d)/2 then
+> if success <> Success or not Size(ri) = Factorial(d)/2 then
 >   Print("wrong result! degree ", d, "\n");
 > fi;
 > od;


### PR DESCRIPTION
Replace legacy true, false, and fail method results by their
symbolic counterparts Success, NeverApplicable, TemporaryFailure.

Co-authored-by: Codex <codex@openai.com>
