### PR TITLE
Switch Success/NeverApplicable/TemporaryFailure values

### DIFF
--- a/gap/base/methsel.gd
+++ b/gap/base/methsel.gd
@@ -131,22 +131,19 @@ DeclareGlobalFunction( "CallMethods" );
 # Possible return values for recognition methods:
 #
 # The method successfully computed a homomorphism (used to be 'true').
-#BindGlobal("Success", MakeImmutable("Success"));
-BindGlobal("Success", true);    # HACK: use old value for now, to ease transition
+BindGlobal("Success", MakeImmutable("Success"));
 
 # The method is never applicable to this kind of group (e.g. input is
 # non-solvable, but method is only applicable to solvable groups; or method
 # only applies to permutation groups, but input is a matrix group). so don't
 # bother to try it again (used to be 'false').
-#BindGlobal("NeverApplicable", MakeImmutable("NeverApplicable"));
-BindGlobal("NeverApplicable", false);    # HACK: use old value for now, to ease transition
+BindGlobal("NeverApplicable", MakeImmutable("NeverApplicable"));
 
 # The method temporarily failed, but it could be sensible to call it again in
 # this situation at a later stage. This value is typical for a Las Vegas
 # algorithm using randomised methods, which has failed, but which may succeed
 # when called again (used to be 'fail').
-#BindGlobal("TemporaryFailure", MakeImmutable("TemporaryFailure"));
-BindGlobal("TemporaryFailure", fail);    # HACK: use old value for now, to ease transition
+BindGlobal("TemporaryFailure", MakeImmutable("TemporaryFailure"));
 
 # The method needs more information (e.g. things like whether group is
 # solvable; transitive; etc.) -> try again later if new information becomes

--- a/tst/working/quick/GenericSnAnUnknownDegree.tst
+++ b/tst/working/quick/GenericSnAnUnknownDegree.tst
@@ -31,7 +31,7 @@ gap> for d in [11] do
 # Check Slp function
 gap> ri := RecogNode(SdOn2Sets);;
 gap> FindHomMethodsGeneric.SnAnUnknownDegree(ri);
-true
+"Success"
 gap> x := PseudoRandom(Grp(ri));;
 gap> slp := SLPforElement(ri, x);;
 gap> x = ResultOfStraightLineProgram(slp, NiceGens(ri));

--- a/tst/working/quick/bugfix.tst
+++ b/tst/working/quick/bugfix.tst
@@ -362,7 +362,7 @@ gap> G := Group(Concatenation(ngens, hgens, [ swap ]));;
 gap> m := GModuleByMats(ngens, f);;
 gap> ri := RecogNode(G, true);;
 gap> RECOG.SortOutReducibleNormalSubgroup(ri, G, ngens, m);
-true
+"Success"
 gap> ri!.comment;
 "D7TensorInduced"
 gap> Size(Image(Homom(ri)));

--- a/tst/working/slow/GenericSnAnUnknownDegree.tst
+++ b/tst/working/slow/GenericSnAnUnknownDegree.tst
@@ -293,7 +293,7 @@ gap> for d in [11 .. 30] do
 # Check Slp function
 gap> ri := RecogNode(S11On2Sets);;
 gap> FindHomMethodsGeneric.SnAnUnknownDegree(ri);
-true
+"Success"
 gap> x := PseudoRandom(Grp(ri));;
 gap> slp := SLPforElement(ri, x);;
 gap> x = ResultOfStraightLineProgram(slp, NiceGens(ri));


### PR DESCRIPTION
... away from true/false/fail. The old values were far too easy to
use incorrectly, so we started the plan to move away from the a
long time ago. But it took time to convert all places the new
return values.
