### PR TITLE
Use PositionNonZeroInRow to simplify or speed up code

### DIFF
--- a/gap/base/projective.gi
+++ b/gap/base/projective.gi
@@ -34,7 +34,7 @@ InstallGlobalFunction( IsEqualProjective,
     local n, p, s;
     n := NrRows(a);
     Assert(1, n > 0 and n = NrRows(b) and n = NrCols(a) and n = NrCols(b));
-    p := First([1..n], i -> not IsZero(a[1,i])); # Find non-zero entry in <a[1]>
+    p := PositionNonZeroInRow(a, 1); # Find non-zero entry in <a[1]>
     Assert(1, p <> fail);
     s := b[1,p] / a[1,p]; # The unique scalar <s> with <s * a[1,p] = b[1,p]>.
     if IsZero(s) then

--- a/gap/matrix/blocks.gi
+++ b/gap/matrix/blocks.gi
@@ -140,16 +140,29 @@ end);
 # the set poss contain only zero elements outside of the
 # positions indicated by poss.
 RECOG.IsDiagonalBlockOfMatrix := function(m, poss)
-  local n, outside, z, i, j;
-  Assert(1, NrRows(m) = NrCols(m) and IsSubset([1..NrRows(m)], poss));
-  outside := Difference([1..NrRows(m)], poss);
-  z := ZeroOfBaseDomain(m);
+  local a, b, n, i;
+  a := First(poss);
+  b := Last(poss);
+  n := NrRows(m);
+  Assert(1, poss = [a..b]);
+  Assert(1, NrRows(m) = NrCols(m) and b <= n);
+  # check for zeros above
+  for i in [1..a-1] do
+    if PositionNonZeroInRow(m, i, a-1) <= b then
+      return false;
+    fi;
+  od;
+  # check for zeros left and right
   for i in poss do
-    for j in outside do
-      if m[i,j] <> z or m[j,i] <> z then
-        return false;
-      fi;
-    od;
+    if PositionNonZeroInRow(m, i) < a or PositionNonZeroInRow(m, i, b) <= n then
+      return false;
+    fi;
+  od;
+  # check for zeros below
+  for i in [b+1..n] do
+    if PositionNonZeroInRow(m, i, a-1) <= b then
+      return false;
+    fi;
   od;
   return true;
 end;
@@ -406,17 +419,18 @@ end);
 # verify that the matrix has block lower triangular shape
 # with respect to the given blocks.
 RECOG.IsBlockLowerTriangularWithBlocks := function(mat, blocks)
-  local z, b, col, row;
-  Assert(0, Concatenation(blocks) = [1..Length(mat)]);
-  z := ZeroOfBaseDomain(mat);
+  local a, b, n, row;
+  n := NrRows(mat);
+  Assert(1, NrCols(mat) = n);
+  Assert(1, Concatenation(blocks) = [1..n]);
   for b in blocks do
+    a := First(b);
+    Assert(1, b = [a..Last(b)]);
     # Verify that there are only zeros above each block
-    for row in [1..b[1]-1] do
-      for col in b do
-        if mat[row,col] <> z then
-          return false;
-        fi;
-      od;
+    for row in [1..a-1] do
+      if PositionNonZeroInRow(mat, row, a-1) <= Last(b) then
+        return false;
+      fi;
     od;
   od;
   return true;

--- a/gap/projective.gi
+++ b/gap/projective.gi
@@ -106,13 +106,14 @@ function(ri)
 end);
 
 SLPforElementFuncsProjective.StabilizerChainProj := function(ri,x)
-  local z, r;
+  local i, z, r;
   # Over GF(2), genss uses OnPoints as an optimization even in projective
   # stabilizer chains. In that case we must normalize extension-field scalar
   # multiples back to a representative over ri!.field before sifting, or else
   # orb hashes the resulting point as the wrong type.
   if IsIdenticalObj(ri!.stabilizerchain!.orb!.op, OnPoints) then
-      z := x[1,PositionNonZero(x[1])];
+      i := PositionNonZeroInRow(x, 1);
+      z := x[1,i];
       if not IsOne(z) then
           x := x / z;
       fi;
@@ -164,7 +165,7 @@ RECOG.HomProjDet := function(data,m)
   # Since the input is projective, it may be scaled out of the node's base
   # field. Normalize by the first non-zero entry in the first row; then either
   # all entries lie in the base field, or else the input is invalid.
-  i := PositionNonZero(m[1]);
+  i := PositionNonZeroInRow(m, 1);
   mm := m;
   if not mm[1,i] in data.field then
       mm := mm / mm[1,i];

--- a/gap/projective/c3c5.gi
+++ b/gap/projective/c3c5.gi
@@ -45,7 +45,7 @@ RECOG.WriteOverBiggerFieldWithSmallerDegree :=
     # field -- in that case, we scale the matrix so that the first non-zero entry
     # is in the right field; then either all entries are, or else the input matrix
     # is not valid and we later return `fail`
-    i := PositionNonZero(gen[1]);
+    i := PositionNonZeroInRow(gen, 1);
     if not gen[1,i] in GF(inforec.q) then
       gen := gen / gen[1,i];
     fi;
@@ -358,7 +358,7 @@ RECOG.ScalarToMultiplyIntoSmallerField := function(m,k)
   if IsPrimeField(k) then
       return fail;
   fi;
-  pos := PositionNonZero(m[1]);
+  pos := PositionNonZeroInRow(m, 1);
   s := m[1,pos]^-1;
   mm := s * m;
   f := FieldOfMatrixList([mm]);
@@ -514,7 +514,7 @@ end;
 RECOG.HomDoBaseAndFieldChangeWithScalarFinding := function(data,el)
   local m,p;
   m := data.t * el * data.ti;
-  p := PositionNonZero(m[1]);
+  p := PositionNonZeroInRow(m, 1);
   m := (m[1,p]^-1) * m;     # this gets rid of any possible scalar
                              # from some bigger field
   return RECOG.ForceToOtherField(m,data.field);

--- a/gap/projective/classicalnatural.gi
+++ b/gap/projective/classicalnatural.gi
@@ -760,7 +760,7 @@ SLPforElementFuncsProjective.PSL2 := function(ri,x)
       ri!.normlist := RECOG.SetupNormalisationListForPSLd(ri!.field,
                                                           ri!.gcd.gcd);
   fi;
-  pos := PositionNonZero(y[1]);
+  pos := PositionNonZeroInRow(y, 1);
   s := RECOG.NormaliseScalarForPSLd(y[1,pos],ri!.normlist);
   slp := RECOG.ExpressInStd_SL2(s * y,ri!.fakegens);
   return slp;
@@ -833,7 +833,7 @@ SLPforElementFuncsProjective.PSLd := function(ri,x)
       ri!.normlist := RECOG.SetupNormalisationListForPSLd(ri!.field,
                                                           ri!.gcd.gcd);
   fi;
-  pos := PositionNonZero(y[1]);
+  pos := PositionNonZeroInRow(y, 1);
   s := RECOG.NormaliseScalarForPSLd(y[1,pos],ri!.normlist);
   slp := RECOG.ExpressInStd_SL(s * y,ri!.fakegens);
   return slp;

--- a/gap/projective/tensor.gi
+++ b/gap/projective/tensor.gi
@@ -173,7 +173,7 @@ RECOG.IsKroneckerProduct := function(m,r)
       return [false];
   fi;
   d := Length(m);
-  pos := PositionNonZero(m[1]);
+  pos := PositionNonZeroInRow(m, 1);
   blockpos := QuoInt(pos-1,blocksize)+1;
   entrypos := ((pos-1) mod blocksize)+1;
   a := ExtractSubMatrix(m,[1..blocksize],

--- a/init.g
+++ b/init.g
@@ -28,3 +28,71 @@ ReadPackage("recog","gap/matrix/classical.gd");
 ReadPackage("recog","gap/projective/almostsimple.gd");
 ReadPackage("recog","gap/projective/findnormal.gd");
 ReadPackage("recog","gap/projective/AnSnOnFDPM.gd");
+
+
+# GAP 4.16.0 introduces PositionNonZeroInRow; add some compatibility shims
+# so that we can use it in older GAP versions, too.
+if not IsBound(PositionNonZeroInRow) then
+
+DeclareOperation( "PositionNonZeroInRow", [ IsMatrixOrMatrixObj, IsPosInt ] );
+DeclareOperation( "PositionNonZeroInRow", [ IsMatrixOrMatrixObj, IsPosInt, IsInt ] );
+
+InstallMethod( PositionNonZeroInRow,
+  "for a row list matrix and a row number",
+  [ IsRowListMatrix, IsPosInt ],
+  function( mat, row )
+    return PositionNonZero( mat[row] );
+  end );
+
+InstallMethod( PositionNonZeroInRow,
+  "for a row list matrix, a row number, and a start position",
+  [ IsRowListMatrix, IsPosInt, IsInt ],
+  function( mat, row, from )
+    return PositionNonZero( mat[row], from );
+  end );
+
+InstallMethod( PositionNonZeroInRow,
+  "for a matrix or matrix object and a row number",
+  [ IsMatrixOrMatrixObj, IsPosInt ],
+  function( mat, row )
+    return PositionNonZeroInRow( mat, row, 0 );
+  end );
+
+InstallMethod( PositionNonZeroInRow,
+  "for a matrix or matrix object, a row number, and a start position",
+  [ IsMatrixOrMatrixObj, IsPosInt, IsInt ],
+  function( mat, row, from )
+    local col, ncols, zero;
+
+    ncols := NrCols( mat );
+    zero := ZeroOfBaseDomain( mat );
+    for col in [ Maximum( 1, from + 1 ) .. ncols ] do
+      if mat[row, col] <> zero then
+        return col;
+      fi;
+    od;
+
+    return ncols + 1;
+  end );
+
+# also use the improved generic IsDiagonalMatrix based on PositionNonZeroInRow
+# for improved performance
+InstallMethod( IsDiagonalMatrix,
+    "for a matrix",
+    [ IsMatrixOrMatrixObj ],
+    function( mat )
+    local i, ncols, p;
+    ncols := NrCols( mat );
+    for i  in [ 1 .. NrRows( mat ) ]  do
+        p := PositionNonZeroInRow( mat, i );
+        if p <= ncols and p <> i then
+            return false;
+        fi;
+        if PositionNonZeroInRow( mat, i, i ) <= ncols then
+            return false;
+        fi;
+    od;
+    return true;
+    end);
+
+fi;

--- a/tst/working/quick/MatBlocks.tst
+++ b/tst/working/quick/MatBlocks.tst
@@ -1,0 +1,28 @@
+gap> blocks := [ [ 1 .. 2 ], [ 3 .. 4 ], [ 5 .. 6 ] ];;
+gap> lower := IdentityMat(6, GF(3));;
+gap> lower[3,1] := Z(3)^0;; lower[5,2] := Z(3)^0;; lower[6,4] := Z(3)^0;;
+gap> RECOG.IsBlockLowerTriangularWithBlocks(lower, blocks);
+true
+gap> upper := StructuralCopy(lower);;
+gap> upper[2,3] := Z(3)^0;;
+gap> RECOG.IsBlockLowerTriangularWithBlocks(upper, blocks);
+false
+gap> diag := IdentityMat(6, GF(3));;
+gap> RECOG.IsDiagonalBlockOfMatrix(diag, [ 3 .. 4 ]);
+true
+gap> above := StructuralCopy(diag);;
+gap> above[2,3] := Z(3)^0;;
+gap> RECOG.IsDiagonalBlockOfMatrix(above, [ 3 .. 4 ]);
+false
+gap> left := StructuralCopy(diag);;
+gap> left[3,2] := Z(3)^0;;
+gap> RECOG.IsDiagonalBlockOfMatrix(left, [ 3 .. 4 ]);
+false
+gap> right := StructuralCopy(diag);;
+gap> right[4,5] := Z(3)^0;;
+gap> RECOG.IsDiagonalBlockOfMatrix(right, [ 3 .. 4 ]);
+false
+gap> below := StructuralCopy(diag);;
+gap> below[5,4] := Z(3)^0;;
+gap> RECOG.IsDiagonalBlockOfMatrix(below, [ 3 .. 4 ]);
+false


### PR DESCRIPTION
Use PositionNonZeroInRow in RECOG.IsDiagonalBlockOfMatrix and
RECOG.IsBlockLowerTriangularWithBlocks for improved speed.

Replace first-row non-zero scans with PositionNonZeroInRow in
projective helper and recognition code.

Since this was only added in GAP 4.16, we provide a fallback
implementation for older GAP versions.

Co-authored-by: Codex <codex@openai.com>
