### PR TITLE
Restore compatibility with the matgrp package

### DIFF
--- a/gap/base/methods.gi
+++ b/gap/base/methods.gi
@@ -86,7 +86,22 @@ end);
 InstallGlobalFunction(BindRecogMethod,
 function(rname, arg...)
     local r, name;
-    r := ValueGlobal(rname);
+    if IsString(rname) then
+      r := ValueGlobal(rname);
+    elif rname = FindHomMethodsMatrix and arg[1] = "Nonfield" and EndsWith(INPUT_FILENAME(), "recograt.gi") then
+      # FIXME/HACK: backwards compatibility for the matgrp package
+      rname := "FindHomMethodsMatrix";
+      r := FindHomMethodsMatrix;
+      arg[Length(arg)] :=
+            function(ri)
+              if IsBound(ri!.ring) and not IsBound(ri!.field) then
+                Error("hereIAm");
+              fi;
+              return NeverApplicable;
+            end;
+    else
+      Error("<rname> must be the name of a global variable containing a record");
+    fi;
     r.(arg[1]) := CallFuncList(RecogMethod, arg);
     name := Concatenation(rname, ".", arg[1]);
     SetNameFunction(r.(arg[1])!.func, name);


### PR DESCRIPTION
... via a crude hack.

Thing is, the arguments for BindRecogMethod, as well as the inputs and outputs of recognition methods have changed.

Luckily the method in matgrp does nothing very useful, so we can replicate an updated version here.

---

See also https://github.com/hulpke/matgrp/pull/19 which addresses this on the matgrp side by simply removing the offending code there (it doesn't do anything useful as far as I can tell). But since we need to be compatible with the current release of matgrp, too, I am making this hackish workaround here (I've also thought about doing a "proper" adapter that is more general, but I don't know of any other external package using these APIs, so I opted to keep it simple.