### PR TITLE
CI: run matgrp tests as part of CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,6 +39,8 @@ jobs:
           cd $GAPROOT/pkg
           ../bin/BuildPackages.sh --strict cvec io orb
       - uses: gap-actions/build-pkg@v3
+      - run: |
+          gap --quitonbreak -c 'SetInfoLevel(InfoObsolete, 0); TestPackage("matgrp");'
       - uses: gap-actions/run-pkg-tests@v4
         with:
           testfile: tst/testall.g


### PR DESCRIPTION
... so we notice breakages sooner in the future.

matgrp is the only distributed GAP package (as far as I know)
which uses recog, and so we should be careful to not break it.
