### PR TITLE
Fix docs github action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,6 +30,7 @@ jobs:
       - uses: gap-actions/build-pkg-docs@v2
         with:
           use-latex: 'true'
+          warnings-as-errors: 'false'
       - name: 'Upload documentation'
         uses: actions/upload-artifact@v7
         with:


### PR DESCRIPTION
Currently, all docs github actions fail even on master. This PR ignores warnings of which we have a lot due to the dynamic structure of the docs.