### PR TITLE
Improve irreducibility checks

### DIFF
--- a/gap/matrix.gi
+++ b/gap/matrix.gi
@@ -40,14 +40,6 @@ RECOG.IsIrreducible := function(ri)
   return ri!.isirreducible;
 end;
 
-RECOG.SetIsIrreducible := function(ri, flag)
-  Assert(0, flag = true or flag = false);
-  if IsBound(ri!.isirreducible) and ri!.isirreducible <> flag then
-    Error("must not change ri!.isirreducible from ", ri!.isirreducible, " to ", flag);
-  fi;
-  ri!.isirreducible := flag;
-end;
-
 # helper for recognition nodes for a matrix group: test if the group
 # acts absolutely irreducibly.
 #
@@ -67,7 +59,8 @@ RECOG.SetIsAbsolutelyIrreducible := function(ri, flag)
   fi;
   ri!.isabsolutelyirred := flag;
   if flag = true then  # absolutely irreducible implies irreducible
-    RECOG.SetIsIrreducible(ri, flag);
+    Assert(0, not (IsBound(ri!.isirreducible) and ri!.isirreducible <> true));
+    ri!.isirreducible := true;
   fi;
 end;
 

--- a/gap/matrix/blocks.gi
+++ b/gap/matrix/blocks.gi
@@ -381,11 +381,6 @@ function(ri)
   G := Grp(ri);
   RECOG.SetPseudoRandomStamp(G,"ReducibleIso");
 
-  if IsBound(ri!.isabsolutelyirred) and ri!.isabsolutelyirred then
-      # this information is coming from above
-      return NeverApplicable;
-  fi;
-
   # Report enduring failure if irreducible:
   if RECOG.IsIrreducible(ri) then
       return NeverApplicable;


### PR DESCRIPTION
Removed unused `RECOG.SetIsIrreducible`, and remove a redundant check in `ReducibleIso`.

As a side effect, now all access to `isirreducible` and `isabsolutelyirred` is confined to the accessor for them in `gap/matrix.gi`.
