### PR TITLE
Add stamps to GroupHomByFuncWithData for RECOG.HomDoBaseChange

### DIFF
--- a/gap/matrix/blocks.gi
+++ b/gap/matrix/blocks.gi
@@ -402,7 +402,7 @@ function(ri)
   newgens := List(GeneratorsOfGroup(G),x->bc.base*x*bc.baseinv);
   H := GroupWithGenerators(newgens);
   hom := GroupHomByFuncWithData(G,H,RECOG.HomDoBaseChange,
-                                rec(t := bc.base,ti := bc.baseinv));
+                                rec(t := bc.base,ti := bc.baseinv, stamp := "ReducibleIso"));
 
   # Now report back:
   SetHomom(ri,hom);

--- a/gap/matrix/matimpr.gi
+++ b/gap/matrix/matimpr.gi
@@ -191,7 +191,7 @@ function(ri)
   newgens := List(GeneratorsOfGroup(G),x->ri!.t*x*ti);
   H := GroupWithGenerators(newgens);
   iso := GroupHomByFuncWithData(G,H,RECOG.HomDoBaseChange,
-                                rec(t := ri!.t,ti := ti));
+                                rec(t := ri!.t,ti := ti, stamp := "DoBaseChangeForBlocks"));
 
   # Now report back:
   SetHomom(ri,iso);

--- a/gap/projective/c3c5.gi
+++ b/gap/projective/c3c5.gi
@@ -838,6 +838,7 @@ function(ri)
           fi;
 
           H := GroupWithGenerators(conjgensG);
+          r.stamp := "C3C5";
           hom := GroupHomByFuncWithData(G,H,RECOG.HomDoBaseChange,r);
           SetHomom(ri,hom);
 

--- a/gap/projective/d247.gi
+++ b/gap/projective/d247.gi
@@ -276,6 +276,7 @@ RECOG.SortOutReducibleNormalSubgroup :=
         fi;
 
         H := GroupWithGenerators(conjgensG);
+        r.stamp := "D247";
         hom := GroupHomByFuncWithData(G,H,RECOG.HomDoBaseChange,r);
         SetHomom(ri,hom);
 

--- a/gap/projective/tensor.gi
+++ b/gap/projective/tensor.gi
@@ -369,6 +369,7 @@ function(ri)
   fi;
 
   H := GroupWithGenerators(conjgensG);
+  r.stamp := "TensorDecomposable";
   hom := GroupHomByFuncWithData(G,H,RECOG.HomDoBaseChange,r);
   SetHomom(ri,hom);
 


### PR DESCRIPTION
These are not used by the code, but they are useful for debugging,
to figure out which of several methods created this homomorphism.
