### PR TITLE
add RECOG.FindSL2inSL4: Find SL(2,q) as stingray subgroup of SL(4,q)

### DIFF
--- a/gap/projective/SL4_natural.gi
+++ b/gap/projective/SL4_natural.gi
@@ -56,7 +56,7 @@
 #############################################################################
 
 
-RECOG.GoingDownFinalStepSL := function(G, N)
+RECOG.FindSL2inSL4 := function(G, N)
     local n, F, q, one, Eigenspace, gens_group, gens_bas, l,
           pr, t, basis1, basism1, bas, basInv,
           h, hb, topLeft, bottomRight, ordr, K, slp, Nstart, U;

--- a/gap/projective/SL4_natural.gi
+++ b/gap/projective/SL4_natural.gi
@@ -1,0 +1,147 @@
+###############################################################################
+##
+##  Authors: Till Eisenbrand
+##           The underlying algorithm is due to Daniel Rademacher; see
+##           Algorithm 15 ("GoingDownFinalStepSL") in:
+##           D. Rademacher, "Constructive Recognition of Finite Classical Groups with
+##           Stingray Elements", Ph.D. thesis, RWTH Aachen University, Germany, 2024.
+##
+##
+##  This file provides the function:
+##
+##    RECOG.GoingDownFinalStepSL(G, N)
+##
+##  Purpose:
+##    Given G = SL(4,q) (q odd), this function finds an embedded copy of
+##    SL(2,q) inside G as a "stingray subgroup".  Concretely, it looks for
+##    a base change matrix  bas  such that, in the new basis, the found
+##    subgroup consists of block matrices of the form
+##
+##        [ A | 0 ]
+##        [ 0 | I ]      with  A in SL(2,q).
+##
+##    The function proceeds by:
+##      1. Searching for a strong pre-involution  t  of type 2+2, i.e. a
+##         non-trivial involution with dim(E_1(t)) = dim(E_{-1}(t)) = 2.
+##      2. Building a base change from the eigenspaces of  t.
+##      3. Drawing random elements from the centraliser C_G(t) via the Bray
+##         trick (RECOG.CentralisingElementOfInvolution) and filtering for
+##         those that act trivially on the lower 2x2 block in the new basis.
+##         Such elements generate the stingray-embedded SL(2,q).
+##      4. Stopping as soon as the collected generators are recognised
+##         (non-constructively) as SL(2,q).
+##
+##  Input:
+##    G  -- a matrix group equal to SL(4,q) for some odd prime power q,
+##           given by 4x4 matrices over GF(q).
+##    N  -- positive integer: random-element budget (number of allowed
+##           calls to the product replacer / Bray trick).
+##
+##  Returns:
+##    "fail"  if the budget N is exhausted before success, OR a record with
+##    the following fields:
+##
+##      .U     -- a subgroup of G with U isomorphic to SL(2,q), stingray
+##                embedded in G with respect to the base change bas.
+##
+##      .bas   -- the 4x4 base change matrix bas such that  u^bas
+##                is block-diagonal diag(A, I_2) for every u in U.
+##
+##      .gens  -- list of generators of U as elements of G (i.e. 4x4
+##                matrices over GF(q)).
+##
+##      .Nout  -- remaining budget after completion  (N - number of random
+##                selections actually used).
+##
+#############################################################################
+
+
+RECOG.GoingDownFinalStepSL := function(G, N)
+    local n, F, q, one, Eigenspace, gens_group, gens_bas, l,
+          pr, t, basis1, basism1, bas, basInv,
+          h, hb, topLeft, bottomRight, ordr, K, slp, Nstart, U;
+
+    n := DimensionOfMatrixGroup(G);
+    F := FieldOfMatrixGroup(G);
+    q := Size(F);
+    one := IdentityMat(n, F);
+    Nstart := N;
+    slp := [];
+
+    if q <10 then
+        l := 3;
+    else 
+        l := 3;
+    fi;
+
+    if n <> 4 then
+        Error("GoingDownFinalStepSL: <G> must act in dimension 4");
+    fi;
+    if q mod 2 = 0 then
+        Error("GoingDownFinalStepSL: q must be odd");
+    fi;
+
+    Eigenspace := function(M, lambda)
+        return NullspaceMat(M - lambda * one);
+    end;
+
+    pr := ProductReplacer(GeneratorsOfGroup(G));
+
+    # find a strong pre-involution: t = x^(|x|/2) of type 2+2.
+    # RECOG.InvolutionSearcher(pr,ord,0) uses exactly one Next(pr).
+    t := fail;
+    while N > 0 do
+        t := RECOG.InvolutionSearcher(pr, Order, 0);
+        N := N - 1;
+        if t <> fail and Length(Eigenspace(t, One(F))) = 2 then
+            break;
+        fi;
+        t := fail;
+    od;
+
+    if t = fail then
+        Print("GoingDownFinalStepSL: out of budget while looking for a strong pre-involution\n");
+        return "fail";
+    fi;
+
+    basis1 := Eigenspace(t, One(F));
+    basism1 := Eigenspace(t, -One(F));
+    basInv := Concatenation(basis1, basism1);
+    bas := basInv^-1;
+
+    gens_bas := [];
+    gens_group := [];
+
+    while N > 0 do
+        h := RECOG.CentralisingElementOfInvolution(pr, Order, t);
+        N := N - 1;
+
+        # Conjugate h into the eigenbasis of t; in this basis C_G(t)
+        # is block-diagonal diag(A, B) with A,B in GL(2,q).
+        hb := basInv * h * bas;
+        topLeft := hb{[1,2]}{[1,2]};
+        bottomRight := hb{[3,4]}{[3,4]};
+
+        # h^ordr kills the lower block (bottomRight^ordr = I_2) while
+        # potentially leaving a non-trivial upper block.
+        ordr := Order(bottomRight);
+        if topLeft^ordr <> IdentityMat(2, F) then
+            Add(gens_bas, topLeft^ordr);
+            Add(gens_group, h^ordr);
+            
+            # Wait until we have enough generators before testing,
+            # to avoid calling RecognizeGroup on trivial/cyclic groups.
+            if Size(gens_bas) >l then
+                K := Group(gens_bas);
+                count := 0;
+                # Non-constructive recognition: check whether the collected
+                # 2x2 generators already span SL(2,q).
+                if Size(RecognizeGroup(K)) = Size(SL(2, q)) then
+                    U := Group(gens_group);
+                    return rec(U := U, bas := bas, gens := gens_group, Nout := N);
+                fi;
+            fi;
+        fi;
+    od;
+    return fail;
+end;

--- a/gap/projective/sl4_natural.gi
+++ b/gap/projective/sl4_natural.gi
@@ -9,7 +9,7 @@
 ##
 ##  This file provides the function:
 ##
-##    RECOG.GoingDownFinalStepSL(G, N)
+##    RECOG.FindSL2inSL4(G, N)
 ##
 ##  Purpose:
 ##    Given G = SL(4,q) (q odd), this function finds an embedded copy of
@@ -53,7 +53,7 @@
 
 
 RECOG.FindSL2inSL4 := function(G, N)
-    local n, F, q, one, Eigenspace, gens_group, gens_bas, l,
+    local n, F, q, one, gens_group, gens_bas, 
           pr, t, basis1, basism1, bas, basInv,
           h, hb, topLeft, bottomRight, ordr, K, slp, Nstart, U;
 
@@ -64,22 +64,12 @@ RECOG.FindSL2inSL4 := function(G, N)
     Nstart := N;
     slp := [];
 
-    if q <10 then
-        l := 3;
-    else 
-        l := 3;
-    fi;
-
     if n <> 4 then
-        Error("GoingDownFinalStepSL: <G> must act in dimension 4");
+        Error("FindSL2inSL4: <G> must act in dimension 4");
     fi;
     if q mod 2 = 0 then
-        Error("GoingDownFinalStepSL: q must be odd");
+        Error("FindSL2inSL4: q must be odd");
     fi;
-
-    Eigenspace := function(M, lambda)
-        return NullspaceMat(M - lambda * one);
-    end;
 
     pr := ProductReplacer(GeneratorsOfGroup(G));
 
@@ -89,19 +79,19 @@ RECOG.FindSL2inSL4 := function(G, N)
     while N > 0 do
         t := RECOG.InvolutionSearcher(pr, Order, 0);
         N := N - 1;
-        if t <> fail and Length(Eigenspace(t, One(F))) = 2 then
+        if t <> fail and Length(RECOG.FixspaceMat(t)) = 2 then
             break;
         fi;
         t := fail;
     od;
 
     if t = fail then
-        Print("GoingDownFinalStepSL: out of budget while looking for a strong pre-involution\n");
-        return "fail";
+        Print("FindSL2inSL4: out of budget while looking for a strong pre-involution\n");
+        return fail;
     fi;
 
-    basis1 := Eigenspace(t, One(F));
-    basism1 := Eigenspace(t, -One(F));
+    basis1 := RECOG.FixspaceMat(t);
+    basism1 := RECOG.EigenspaceMat(t, -One(F));
     basInv := Concatenation(basis1, basism1);
     bas := basInv^-1;
 
@@ -124,17 +114,11 @@ RECOG.FindSL2inSL4 := function(G, N)
         if topLeft^ordr <> IdentityMat(2, F) then
             Add(gens_bas, topLeft^ordr);
             Add(gens_group, h^ordr);
-            
-            # Wait until we have enough generators before testing,
-            # to avoid calling RecognizeGroup on trivial/cyclic groups.
-            if Size(gens_bas) >l then
-                K := Group(gens_bas);
-                # Non-constructive recognition: check whether the collected
-                # 2x2 generators already span SL(2,q).
-                if Size(RecognizeGroup(K)) = Size(SL(2, q)) then
-                    U := Group(gens_group);
-                    return rec(U := U, bas := bas, gens := gens_group, Nout := N);
-                fi;
+            # Non-constructive recognition: check whether the collected
+            # 2x2 generators already span SL(2,q).
+            if RECOG.IsThisSL2Natural(gens_bas,GF(q)) then
+                U := Group(gens_group);
+                return rec(U := U, bas := bas, gens := gens_group, Nout := N);
             fi;
         fi;
     od;

--- a/gap/projective/sl4_natural.gi
+++ b/gap/projective/sl4_natural.gi
@@ -34,8 +34,7 @@
 ##  Input:
 ##    G  -- a matrix group equal to SL(4,q) for some odd prime power q,
 ##           given by 4x4 matrices over GF(q).
-##    N  -- positive integer: random-element budget (number of allowed
-##           calls to the product replacer / Bray trick).
+##    N  -- positive integer: random-element budget.
 ##
 ##  Returns:
 ##    "fail"  if the budget N is exhausted before success, OR a record with
@@ -43,13 +42,10 @@
 ##
 ##      .U     -- a subgroup of G with U isomorphic to SL(2,q), stingray
 ##                embedded in G with respect to the base change bas.
-##
 ##      .bas   -- the 4x4 base change matrix bas such that  u^bas
 ##                is block-diagonal diag(A, I_2) for every u in U.
-##
 ##      .gens  -- list of generators of U as elements of G (i.e. 4x4
 ##                matrices over GF(q)).
-##
 ##      .Nout  -- remaining budget after completion  (N - number of random
 ##                selections actually used).
 ##
@@ -133,7 +129,6 @@ RECOG.FindSL2inSL4 := function(G, N)
             # to avoid calling RecognizeGroup on trivial/cyclic groups.
             if Size(gens_bas) >l then
                 K := Group(gens_bas);
-                count := 0;
                 # Non-constructive recognition: check whether the collected
                 # 2x2 generators already span SL(2,q).
                 if Size(RecognizeGroup(K)) = Size(SL(2, q)) then

--- a/gap/projective/sl4_natural.gi
+++ b/gap/projective/sl4_natural.gi
@@ -9,7 +9,7 @@
 ##
 ##  This file provides the function:
 ##
-##    RECOG.FindSL2inSL4(G, N)
+##    RECOG.FindSL2inSL4_natural(G, N)
 ##
 ##  Purpose:
 ##    Given G = SL(4,q) (q odd), this function finds an embedded copy of
@@ -52,19 +52,19 @@
 #############################################################################
 
 
-RECOG.FindSL2inSL4 := function(G, N)
-    local n, F, q, one, gens_group, gens_bas, 
+RECOG.FindSL2inSL4_natural := function(G, N)
+    local F, q, one, gens_group, gens_bas, 
           pr, t, basis1, basism1, bas, basInv,
-          h, hb, topLeft, bottomRight, ordr, K, slp, Nstart, U;
+          h, hb, topLeft, bottomRight, ordr, ordu, K, Nstart,
+          U, readyqm1, readyqpl1, count, image, u;
 
-    n := DimensionOfMatrixGroup(G);
+    
     F := FieldOfMatrixGroup(G);
     q := Size(F);
-    one := IdentityMat(n, F);
+    one := IdentityMat(4, F);
     Nstart := N;
-    slp := [];
 
-    if n <> 4 then
+    if DimensionOfMatrixGroup(G) <> 4 then
         Error("FindSL2inSL4: <G> must act in dimension 4");
     fi;
     if q mod 2 = 0 then
@@ -75,22 +75,22 @@ RECOG.FindSL2inSL4 := function(G, N)
 
     # find a strong pre-involution: t = x^(|x|/2) of type 2+2.
     # RECOG.InvolutionSearcher(pr,ord,0) uses exactly one Next(pr).
-    t := fail;
     while N > 0 do
         t := RECOG.InvolutionSearcher(pr, Order, 0);
         N := N - 1;
-        if t <> fail and Length(RECOG.FixspaceMat(t)) = 2 then
-            break;
+        if t <> fail then
+            basis1 := RECOG.FixspaceMat(t); # note that RECOG.FixspaceMat works with elements with memory too
+            if Length(basis1) = 2 then
+                break;
+            fi;
         fi;
-        t := fail;
     od;
 
-    if t = fail then
-        Print("FindSL2inSL4: out of budget while looking for a strong pre-involution\n");
+    if N = 0 then
+        Info(InfoRecog, 2, "FindSL2inSL4: out of budget while looking for a strong pre-involution");
         return fail;
     fi;
 
-    basis1 := RECOG.FixspaceMat(t);
     basism1 := RECOG.EigenspaceMat(t, -One(F));
     basInv := Concatenation(basis1, basism1);
     bas := basInv^-1;
@@ -102,23 +102,34 @@ RECOG.FindSL2inSL4 := function(G, N)
         h := RECOG.CentralisingElementOfInvolution(pr, Order, t);
         N := N - 1;
 
-        # Conjugate h into the eigenbasis of t; in this basis C_G(t)
-        # is block-diagonal diag(A, B) with A,B in GL(2,q).
         hb := basInv * h * bas;
         topLeft := hb{[1,2]}{[1,2]};
         bottomRight := hb{[3,4]}{[3,4]};
 
-        # h^ordr kills the lower block (bottomRight^ordr = I_2) while
-        # potentially leaving a non-trivial upper block.
         ordr := Order(bottomRight);
-        if topLeft^ordr <> IdentityMat(2, F) then
-            Add(gens_bas, topLeft^ordr);
+        topLeft := topLeft^ordr;
+        if not IsOne(topLeft) then
+            Add(gens_bas, topLeft);
             Add(gens_group, h^ordr);
-            # Non-constructive recognition: check whether the collected
-            # 2x2 generators already span SL(2,q).
-            if RECOG.IsThisSL2Natural(gens_bas,GF(q)) then
-                U := Group(gens_group);
-                return rec(U := U, bas := bas, gens := gens_group, Nout := N);
+
+            # nur die letzten k Erzeuger zum Testen benutzen
+            if Length(gens_bas) > 2 then
+                image := Group(gens_bas);
+                readyqm1 := false;
+                readyqpl1 := false;
+                count := 0;
+                repeat
+                    u := PseudoRandom(image);
+                    ordu := Order(u);
+                    if ordu = q-1 then readyqm1 := true; fi;
+                    if ordu = q+1 then readyqpl1 := true; fi;
+                    count := count + 1;
+                until (readyqm1 and readyqpl1) or count = 20;
+
+                if readyqm1 and readyqpl1 then
+                    U := Group(gens_group);
+                    return rec(U := U, bas := bas, gens := gens_group, Nout := N);
+                fi;
             fi;
         fi;
     od;

--- a/read.g
+++ b/read.g
@@ -54,6 +54,7 @@ ReadPackage("recog","gap/projective/almostsimple/lietype.gi");
 ReadPackage("recog","gap/projective/almostsimple/hints.gi");
 ReadPackage("recog","gap/projective/classicalnatural.gi");
 ReadPackage("recog","gap/projective/sl2_natural.gi");
+ReadPackage("recog","gap/projective/sl4_natural.gi");
 ReadPackage("recog","gap/projective/sl.gi");
 ReadPackage("recog","gap/projective/AnSnOnFDPM.gi");
 

--- a/tst/working/quick/sl4.tst
+++ b/tst/working/quick/sl4.tst
@@ -22,7 +22,7 @@ gap> testFindSL2inSL4 := function(q)
 >   od;
 >   return true;
 > end;;
-gap> list := Filtered([3..100], q -> IsPrimePowerInt(q) and q mod 2 = 1);;
+gap> list := Filtered([3..100], q -> IsOddInt(q) and IsPrimePowerInt(q));;
 gap> for q in list do
 >   if not testFindSL2inSL4(q) then
 >     Print("FAILED for q = ", q, "\n");

--- a/tst/working/quick/sl4.tst
+++ b/tst/working/quick/sl4.tst
@@ -1,0 +1,31 @@
+gap> SetInfoLevel(InfoRecog,0); SetInfoLevel(InfoMethSel,0);
+gap> START_TEST("sl4.tst");
+gap> testFindSL2inSL4 := function(q)
+>   local G, res, h, hb, F;
+>   F := GF(q);
+>   G := SL(4, q);
+>   res := RECOG.FindSL2inSL4(G, 2000);
+>   if res = fail then
+>     return false;
+>   fi;
+>   for h in res.gens do
+>     hb := res.bas^-1 * h * res.bas;
+>     if hb{[3,4]}{[3,4]} <> IdentityMat(2, F) then
+>       return false;
+>     fi;
+>     if hb{[1,2]}{[3,4]} <> NullMat(2, 2, F) then
+>       return false;
+>     fi;
+>     if hb{[3,4]}{[1,2]} <> NullMat(2, 2, F) then
+>       return false;
+>     fi;
+>   od;
+>   return true;
+> end;;
+gap> list := Filtered([3..100], q -> IsPrimePowerInt(q) and q mod 2 = 1);;
+gap> for q in list do
+>   if not testFindSL2inSL4(q) then
+>     Print("FAILED for q = ", q, "\n");
+>   fi;
+> od;
+gap> STOP_TEST("sl4.tst");

--- a/tst/working/quick/sl4.tst
+++ b/tst/working/quick/sl4.tst
@@ -4,7 +4,7 @@ gap> testFindSL2inSL4 := function(q)
 >   local G, res, h, hb, F;
 >   F := GF(q);
 >   G := SL(4, q);
->   res := RECOG.FindSL2inSL4(G, 2000);
+>   res := RECOG.FindSL2inSL4_natural(G, 2000);
 >   if res = fail then
 >     return false;
 >   fi;


### PR DESCRIPTION
This PR adds `gap/projective/SL4_natural.gi`, which implements `RECOG.FindSL2inSL4(G, N)`.

Given G = SL(4,q) (q odd), the function finds a subgroup U isomorphic to SL(2,q) stingray-embedded in G: concretely, a base change matrix `bas` is computed such that every element of U is block-diagonal diag(A, I_2) in the new basis.