### PR TITLE
Fix C3 kernel seeding bug

### DIFF
--- a/gap/projective/c3c5.gi
+++ b/gap/projective/c3c5.gi
@@ -684,6 +684,8 @@ function(ri)
           hom := GroupHomByFuncWithData(G,H,RECOG.HomCommutator,r);
           SetHomom(ri,hom);
           Setmethodsforimage(ri,FindHomDbMatrix);
+          # Generators mapping trivially into the image already lie in the
+          # kernel and should be handed to kernel recognition immediately.
           poss := Filtered([1..Length(gensim)],i->IsOne(gensim[i]));
           Append(gensN(ri),ri!.gensHmem{poss});
           findgensNmeth(ri).args[1] := 5;
@@ -784,6 +786,10 @@ function(ri)
           fi;
           Add(gensim,cyc^cc[pos]);
       od;
+      # Generators with trivial field-automorphism action are kernel elements
+      # and help avoid recognizing only a proper subgroup of that kernel.
+      poss := Filtered([1..Length(gensim)], i -> IsOne(gensim[i]));
+      Append(gensN(ri), ri!.gensHmem{poss});
       Info(InfoRecog, 2, StringFormatted(
            "G is C3, found action as field auts of size {}.", deg));
       HH := GroupWithGenerators(gensim);

--- a/tst/working/quick/bugfix.tst
+++ b/tst/working/quick/bugfix.tst
@@ -423,6 +423,23 @@ true
 gap> ForAll(GeneratorsOfGroup(G), x -> SLPforElement(ri, x) <> fail);
 true
 
+# Issue #503: the C3/C5 semilinear branch must seed generators with trivial
+# field-automorphism action into the kernel, otherwise kernel recognition can
+# settle on a proper subgroup and fail final verification.
+# See https://github.com/gap-packages/recog/issues/503
+gap> x1 := [ [ Z(11)^7, Z(11)^0 ], [ Z(11)^8, Z(11)^5 ] ];;
+gap> x2 := [ [ Z(11)^5, 0*Z(11) ], [ 0*Z(11), Z(11)^5 ] ];;
+gap> x3 := [ [ Z(11)^4, Z(11) ], [ Z(11)^6, Z(11)^9 ] ];;
+gap> G := Group([x1, x2, x3]);;
+gap> i := 35;; Reset(GlobalRandomSource, i);; Reset(GlobalMersenneTwister, i);;
+gap> ri := RecognizeGroup(G);;
+gap> IsReady(ri);
+true
+gap> Size(ri);
+24
+gap> ForAll(GeneratorsOfGroup(G), x -> SLPforElement(ri, x) <> fail);
+true
+
 #
 gap> SetInfoLevel(InfoRecog, oldInfoLevel);
 gap> STOP_TEST("bugfix.tst");

--- a/tst/working/quick/bugfix.tst
+++ b/tst/working/quick/bugfix.tst
@@ -437,7 +437,7 @@ gap> IsReady(ri);
 true
 gap> Size(ri);
 24
-gap> ForAll(GeneratorsOfGroup(G), x -> SLPforElement(ri, x) <> fail);
+gap> IsCorrect(ri);
 true
 
 #


### PR DESCRIPTION
Seed trivial-image generators into the C3 kernel and add short comments explaining why both kernel-seeding sites do this.

Fixes #503

Co-authored-by: Codex <codex@openai.com>