### PR TITLE
Avoid SnAnUnknownDegree before projective pass

### DIFF
--- a/gap/generic/SnAnUnknownDegree.gi
+++ b/gap/generic/SnAnUnknownDegree.gi
@@ -1255,6 +1255,13 @@ BindRecogMethod("FindHomMethodsGeneric", "SnAnUnknownDegree",
 function(ri)
     local recogData, isoData, degree, swapSLP, t;
 
+    # For matrix groups, run this method only after passing to the projective
+    # image. Otherwise hidden scalar kernels can make a non-projective group
+    # non-isomorphic to Sn/An while still looking like one modulo scalars.
+    if IsMatrixGroup(Grp(ri)) and not ri!.projective then
+        return NeverApplicable;
+    fi;
+
     # For matrix groups, our degree bounds assume irreducibility. Which
     # should normally be the case here, as the `ReducibleIso` recognition
     # method normally has a higher rank than this one and thus runs first.

--- a/gap/matrix.gi
+++ b/gap/matrix.gi
@@ -183,8 +183,6 @@ AddMethod(FindHomDbMatrix, FindHomMethodsGeneric.FewGensAbelian, 1050);
 
 AddMethod(FindHomDbMatrix, FindHomMethodsMatrix.ReducibleIso, 1000);
 
-AddMethod(FindHomDbMatrix, FindHomMethodsGeneric.SnAnUnknownDegree, 950);
-
 AddMethod(FindHomDbMatrix, FindHomMethodsMatrix.GoProjective, 900);
 
 

--- a/tst/utils.g
+++ b/tst/utils.g
@@ -1,9 +1,8 @@
 TestRecogGL := function(d,q)
     local h, gens, g, ri, r, stamp;
     h := GL(d,q);
-    gens := List([1..10],x->PseudoRandom(h));
-    # FIXME: while this is a generating set with HIGH PROBABILITY, it is not always one.
-    # This could lead to spurious failures in the test suite...
+    # (ab)use product replacement algorithm to get randomized generators
+    gens := ProductReplacer(h)!.team;
     g := GroupWithGenerators(gens);
     ri := RECOG.TestGroup(g,false,Size(h));
     r := ri;

--- a/tst/working/quick/bugfix.tst
+++ b/tst/working/quick/bugfix.tst
@@ -452,6 +452,36 @@ true
 gap> Size(ri) = Size(GL(19,5));
 true
 
+# Issue #510: SnAnUnknownDegree must not spend a long time on this
+# non-projective matrix group with a hidden nontrivial scalar.
+# See https://github.com/gap-packages/recog/issues/510
+gap> gens := Z(3)^0 * [
+> [ [ 1, 0, 0, 0, 0, 0 ],
+> [ 1, 1, 1, 1, 1, 0 ],
+> [ 0, 0, 1, 0, 0, 0 ],
+> [ 2, 0, 0, 1, 2, 0 ],
+> [ 0, 0, 0, 0, 1, 0 ],
+> [ 1, 0, 1, 1, 1, 1 ] ],
+> [ [ 1, 2, 2, 1, 0, 2 ],
+> [ 0, 1, 0, 0, 0, 0 ],
+> [ 2, 0, 0, 2, 0, 2 ],
+> [ 1, 0, 2, 0, 0, 2 ],
+> [ 0, 1, 2, 0, 1, 2 ],
+> [ 1, 1, 1, 1, 0, 1 ] ],
+> [ [ 2, 0, 0, 0, 0, 0 ],
+> [ 0, 2, 0, 0, 0, 0 ],
+> [ 0, 0, 2, 0, 0, 0 ],
+> [ 0, 0, 0, 2, 0, 0 ],
+> [ 0, 0, 0, 0, 2, 0 ],
+> [ 0, 0, 0, 0, 0, 2 ] ]
+> ];;
+gap> G := Group([gens[3] * gens[1], gens[1], gens[2]]);;
+gap> ForAny(GeneratorsOfGroup(G), RECOG.IsScalarMat);
+false
+gap> i := 1;; Reset(GlobalRandomSource, i);; Reset(GlobalMersenneTwister, i);;
+gap> FindHomMethodsGeneric.SnAnUnknownDegree(RecogNode(G));
+"NeverApplicable"
+
 #
 gap> SetInfoLevel(InfoRecog, oldInfoLevel);
 gap> STOP_TEST("bugfix.tst");


### PR DESCRIPTION
Otherwise certain inputs (e.g. a copy A7 times scalar matrices) could result in recog getting stuck.

Co-authored-by: Codex <codex@openai.com>

Fixes #510

CC @chseeger