### PR TITLE
Fix SL godown eigenspace dimension check

### DIFF
--- a/gap/projective/sl.gi
+++ b/gap/projective/sl.gi
@@ -265,7 +265,7 @@ end;
 RECOG.SLn_godownfromd:=function(g,q,d,dim)
   local y,yy,ready,order,es,dims,subsp,z,x,a,b,c,h,vec,vec2,
   pol,factors,degrees,comm1,comm2,comm3,image,basis,action,vs,readyqpl1,
-  readyqm1,count,u,orderu;
+  readyqm1,count,u,orderu,expecteddims;
 
   repeat
     ready:=false;
@@ -283,7 +283,11 @@ RECOG.SLn_godownfromd:=function(g,q,d,dim)
        if not IsOne(yy) then
             es:= Eigenspaces(GF(q),yy);
             dims:=List(es,Dimension);
-            if IsSubset(Set([1,d-1,dim-d]),Set(dims)) and
+            # Since yy^(q-1)=1, yy is semisimple over GF(q).  We want
+            # one 1-space, one (d-1)-space, and the fixed outside space
+            # of dimension dim-d; the last one is absent when dim=d.
+            expecteddims:=Filtered([1,d-1,dim-d], x -> x > 0);
+            if AsSortedList(dims)=AsSortedList(expecteddims) and
                (1 in Set(dims)) then
                es:=Filtered(es,x->Dimension(x)=1);
                vec:=Basis(es[1])[1];

--- a/gap/projective/sl.gi
+++ b/gap/projective/sl.gi
@@ -287,8 +287,7 @@ RECOG.SLn_godownfromd:=function(g,q,d,dim)
             # one 1-space, one (d-1)-space, and the fixed outside space
             # of dimension dim-d; the last one is absent when dim=d.
             expecteddims:=Filtered([1,d-1,dim-d], x -> x > 0);
-            if AsSortedList(dims)=AsSortedList(expecteddims) and
-               (1 in Set(dims)) then
+            if AsSortedList(dims)=AsSortedList(expecteddims) then
                es:=Filtered(es,x->Dimension(x)=1);
                vec:=Basis(es[1])[1];
                if vec*yy=vec then

--- a/tst/working/slow/bugfix.tst
+++ b/tst/working/slow/bugfix.tst
@@ -26,6 +26,17 @@ gap> for i in [1..50] do
 >     ri := RECOG.TestGroup(GL(8,27), false, Size(GL(8,27)));
 > od;
 
+# The following test used to run into an error because SLn_godownfromd
+# accepted eigenspace dimensions which did not include the expected
+# fixed-space dimension.
+gap> seed:=1;;
+gap> Reset(GlobalMersenneTwister, seed);;
+gap> Reset(GlobalRandomSource, seed);;
+gap> h := GL(6,8);;
+gap> gens := List([1..10], x -> PseudoRandom(h));;
+gap> g := GroupWithGenerators(gens);;
+gap> ri := RECOG.TestGroup(g, false, Size(h));;
+
 #
 gap> SetInfoLevel(InfoRecog, oldInfoLevel);
 gap> STOP_TEST("bugfix.tst");


### PR DESCRIPTION
This prevents non-invariant spaces from reaching LinearAction.

Co-authored-by: Codex <codex@openai.com>
